### PR TITLE
feat: Route Service CRUD + 다익스트라 + TMap + 혼잡도 가중 경로

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,252 @@
+# Loopang Route Service
+
+loopang MSA 프로젝트의 허브 간 경로 관리 서비스.
+17개 허브 간 거리/시간을 TMap API로 계산하고, 다익스트라로 최단 경로를 제공한다.
+
+## 기술 스택
+
+- Java 21, Spring Boot 3.5.13, Spring Cloud 2025.0.1
+- Spring MVC (Servlet 기반)
+- 공통 모듈: `com.loopang:common:0.0.5-SNAPSHOT`
+- PostgreSQL 17, JPA + QueryDSL
+- TMap API (허브 간 실제 도로 거리/시간 계산)
+- OpenFeign (hub-service 상태 조회)
+- Eureka Client + Config Server
+- Lombok, Gradle
+- server.port = 18105
+
+## 핵심 기능
+
+1. **허브 라우트 CRUD** — 허브 간 직접 경로 관리 (from → to, 거리/시간)
+2. **경로 계산 API** — 출발/도착 허브 → 다익스트라 최단 경로 (경유 허브 포함)
+3. **TMap 스케줄러** — 1시간마다 17x17 허브 간 실제 도로 거리/시간 자동 갱신
+4. **혼잡도 가중 경로** — 허브 상태(NORMAL/BUSY/FULL) 기반 경로 우회
+5. **150km 초과 비활성화** — 직접 연결 거리 150km 초과 시 is_active = false
+
+## 17개 허브
+
+| 번호 | 이름 | 주소 |
+|---|---|---|
+| 1 | 서울특별시 센터 | 서울특별시 송파구 송파대로 55 |
+| 2 | 경기 북부 센터 | 경기도 고양시 덕양구 권율대로 570 |
+| 3 | 경기 남부 센터 | 경기도 이천시 덕평로 257-21 |
+| 4 | 부산광역시 센터 | 부산 동구 중앙대로 206 |
+| 5 | 대구광역시 센터 | 대구 북구 태평로 161 |
+| 6 | 인천광역시 센터 | 인천 남동구 정각로 29 |
+| 7 | 광주광역시 센터 | 광주 서구 내방로 111 |
+| 8 | 대전광역시 센터 | 대전 서구 둔산로 100 |
+| 9 | 울산광역시 센터 | 울산 남구 중앙로 201 |
+| 10 | 세종특별자치시 센터 | 세종특별자치시 한누리대로 2130 |
+| 11 | 강원특별자치도 센터 | 강원특별자치도 춘천시 중앙로 1 |
+| 12 | 충청북도 센터 | 충북 청주시 상당구 상당로 82 |
+| 13 | 충청남도 센터 | 충남 홍성군 홍북읍 충남대로 21 |
+| 14 | 전북특별자치도 센터 | 전북특별자치도 전주시 완산구 효자로 225 |
+| 15 | 전라남도 센터 | 전남 무안군 삼향읍 오룡길 1 |
+| 16 | 경상북도 센터 | 경북 안동시 풍천면 도청대로 455 |
+| 17 | 경상남도 센터 | 경남 창원시 의창구 중앙대로 300 |
+
+## API 엔드포인트
+
+### CRUD
+
+| 메서드 | URL | 설명 | 권한 |
+|---|---|---|---|
+| POST | `/api/hub-routes` | 라우트 등록 | MASTER |
+| GET | `/api/hub-routes/{routeId}` | 라우트 단건 조회 | 전체 |
+| GET | `/api/hub-routes` | 라우트 목록 조회 (페이징) | 전체 |
+| PATCH | `/api/hub-routes/{routeId}` | 라우트 수정 | MASTER |
+| DELETE | `/api/hub-routes/{routeId}` | 라우트 삭제 | MASTER |
+
+### 경로 계산 (핵심)
+
+| 메서드 | URL | 설명 | 권한 |
+|---|---|---|---|
+| POST | `/api/hub-routes/calculate` | 최단 경로 계산 (다익스트라 + 혼잡도 가중) | 전체 |
+
+### 경로 계산 요청
+
+```json
+POST /api/hub-routes/calculate
+{
+  "fromHubId": "00000000-0000-0000-0000-000000000001",
+  "toHubId": "00000000-0000-0000-0000-000000000004"
+}
+```
+
+### 경로 계산 응답
+
+```json
+{
+  "data": {
+    "fromHubId": "00000000-0000-0000-0000-000000000001",
+    "toHubId": "00000000-0000-0000-0000-000000000004",
+    "path": [
+      { "sequence": 1, "hubId": "00000000-0000-0000-0000-000000000001" },
+      { "sequence": 2, "hubId": "00000000-0000-0000-0000-000000000012" },
+      { "sequence": 3, "hubId": "00000000-0000-0000-0000-000000000016" },
+      { "sequence": 4, "hubId": "00000000-0000-0000-0000-000000000005" },
+      { "sequence": 5, "hubId": "00000000-0000-0000-0000-000000000004" }
+    ],
+    "routeEdges": [
+      { "sequence": 1, "fromHubId": "..001", "toHubId": "..012", "distance": 125.9, "duration": 111.8 },
+      { "sequence": 2, "fromHubId": "..012", "toHubId": "..016", "distance": 144.5, "duration": 120.4 },
+      { "sequence": 3, "fromHubId": "..016", "toHubId": "..005", "distance": 97.3, "duration": 84.8 },
+      { "sequence": 4, "fromHubId": "..005", "toHubId": "..004", "distance": 113.0, "duration": 103.5 }
+    ],
+    "totalDistance": 480.7,
+    "totalDuration": 420.5
+  },
+  "message": "허브 경로 계산에 성공했습니다."
+}
+```
+
+## 경로 계산 알고리즘
+
+### 다익스트라 + 혼잡도 가중
+
+활성(is_active=true) 라우트만 사용하여 최단 경로를 계산한다.
+경유 허브의 혼잡도에 따라 비용을 가중하여 혼잡한 허브를 자연스럽게 우회한다.
+
+| 허브 상태 | 가중 계수 | 비용 계산 | 설명 |
+|---|---|---|---|
+| NORMAL (정상) | 0% | `cost = distance` | 가중 없음 |
+| BUSY (혼잡) | 80% | `cost = distance x 1.8` | 거리 80% 가중 |
+| FULL (만원) | 200% | `cost = distance x 3.0` | 거리 200% 가중 |
+
+- 응답의 distance/duration은 **실제 값** (가중되지 않은 원본)
+- 가중은 **경로 선택에만** 영향 (어떤 허브를 경유할지 결정)
+- Hub Service Feign으로 실시간 허브 상태 조회
+- Feign 실패 시 기본값 NORMAL로 처리
+
+### TMap API 스케줄러
+
+- 1시간마다 17x16=272개 허브 쌍의 실제 도로 거리/시간 갱신
+- TMap API로 실제 도로 기반 거리(km), 시간(min) 계산
+- 150km 초과 라우트는 is_active = false (직접 연결 비활성, 경유로만 도달)
+- API 간 200ms 딜레이 (rate limit 대응)
+
+### 초기 데이터
+
+- 서버 시작 시 17x16=272개 라우트 자동 생성 (Haversine 직선거리)
+- TMap 스케줄러가 실행되면 실제 도로 거리로 갱신
+
+## 테이블: p_hub_route
+
+| 컬럼 | 타입 | 제약 | 설명 |
+|---|---|---|---|
+| route_id | UUID | PK | 라우트ID |
+| from_hub_id | UUID | NOT NULL | 출발허브ID |
+| from_name | VARCHAR(100) | NULL | 출발허브이름 |
+| to_hub_id | UUID | NOT NULL | 도착허브ID |
+| to_name | VARCHAR(100) | NULL | 도착허브이름 |
+| distance | Double | NOT NULL | 거리 (km) |
+| duration | Double | NOT NULL | 시간 (minutes) |
+| is_active | BOOLEAN | NOT NULL | 활성화 (150km 이내) |
+| refreshed_at | TIMESTAMP | NULL | TMap 갱신 시점 |
+| version | INT | | 낙관적 락 |
+| + BaseUserEntity |
+
+## 다른 서비스 연동 방법
+
+### 배송 서비스 (Delivery Service)
+
+배송 생성 시 경로 계산을 요청합니다:
+
+```text
+1. Feign Client 정의:
+   FeignClient(name = "route-service")
+   PostMapping("/api/hub-routes/calculate")
+
+2. 요청: { fromHubId: 공급업체허브, toHubId: 수령업체허브 }
+
+3. 응답 활용:
+   - path: 경유 허브 목록 → p_delivery_route의 sequence별 departure/destination
+   - routeEdges: 구간별 거리/시간 → expected_distance, expected_time
+   - totalDistance/Duration: 전체 배송 예상 거리/시간
+```
+
+### 주문 서비스 (Order Service)
+
+주문 생성 시 예상 배송 시간 조회 (선택):
+
+```text
+Feign으로 /api/hub-routes/calculate 호출 → totalDuration으로 예상 소요 시간 제공
+```
+
+### 전체 배송 흐름
+
+```text
+업체A → (TMap: 업체→허브) → 출발허브
+  → (다익스트라: 허브 간 최단 경로, 혼잡도 가중)
+  → 경유허브1 → 경유허브2 → 도착허브
+  → (TMap: 허브→업체) → 업체B
+```
+
+- 허브 간: Route Service (다익스트라 + TMap 데이터)
+- 업체 ↔ 허브: Delivery Service에서 TMap 직접 호출
+
+## 예외 처리
+
+| 클래스 | HTTP | 설명 |
+|---|---|---|
+| RouteNotFoundException | 404 | 라우트를 찾을 수 없습니다 |
+| RouteCalculationException | 404 | 경로를 찾을 수 없습니다 (도달 불가) |
+| DuplicateRouteException | 409 | 이미 존재하는 라우트입니다 |
+
+## 패키지 구조
+
+```text
+com.loopang.route_service
+├── application/
+│   └── RouteService.java
+├── domain/
+│   ├── entity/HubRoute.java
+│   ├── repository/HubRouteRepository.java
+│   ├── exception/
+│   └── service/
+│       ├── RouteCalculator.java
+│       ├── TMapProvider.java
+│       ├── HubStatusProvider.java
+│       └── dto/HubStatusData.java
+├── infrastructure/
+│   ├── persistence/JpaHubRouteRepository.java
+│   ├── route/DijkstraRouteCalculator.java
+│   ├── tmap/TMapProviderImpl.java, TMapProperties.java
+│   ├── client/HubFeignClient.java, HubStatusProviderImpl.java
+│   ├── scheduler/TMapRefreshScheduler.java
+│   └── init/HubRouteInitializer.java
+└── presentation/
+    ├── RouteController.java
+    └── dto/request, response
+```
+
+## 로컬 실행
+
+### 사전 조건
+- Eureka Server (18761)
+- Config Server (18888)
+- PostgreSQL Docker (5435, DB: route)
+- Hub Service (18100) — 혼잡도 가중 경로에 필요
+
+### 환경변수 (IntelliJ Run Configuration)
+```text
+TMAP_API_KEY=본인TMap키;DB_URL=localhost:5435/route;DB_USERNAME=postgres;DB_PASSWORD=본인비밀번호
+```
+
+## 구현 현황
+
+### 완료
+- [x] HubRoute 엔티티 + CRUD + MASTER 권한 체크
+- [x] 다익스트라 경로 계산 (is_active=true만)
+- [x] 혼잡도 가중 경로 (Hub Service Feign 조회, NORMAL/BUSY/FULL)
+- [x] TMap API 연동 (실제 도로 거리/시간 계산)
+- [x] TMap 스케줄러 (1시간 갱신, 150km 초과 비활성화)
+- [x] 초기 데이터 (17x16=272개 Haversine 라우트 자동 생성)
+- [x] 예외 분리 (RouteNotFoundException, RouteCalculationException, DuplicateRouteException)
+
+### TODO
+- [ ] Kafka 연동 (Hub 변경 이벤트 수신 → 라우트 재계산)
+- [ ] Redis 캐싱 (경로 계산 결과 캐싱, TTL 1시간)
+- [ ] 검색 필터 (from_hub_id, to_hub_id, is_active — QueryDSL)
+- [ ] SecurityUtil 전환
+- [ ] Dockerfile + Docker 배포 + CI/CD

--- a/src/main/java/com/loopang/route_service/application/RouteService.java
+++ b/src/main/java/com/loopang/route_service/application/RouteService.java
@@ -5,6 +5,7 @@ import com.loopang.route_service.domain.exception.DuplicateRouteException;
 import com.loopang.route_service.domain.exception.RouteNotFoundException;
 import com.loopang.route_service.domain.repository.HubRouteRepository;
 import com.loopang.route_service.domain.service.RouteCalculator;
+import com.loopang.route_service.domain.service.dto.RouteCalculationResult;
 import com.loopang.route_service.presentation.dto.request.RouteCalculateRequest;
 import com.loopang.route_service.presentation.dto.request.RouteCreateRequest;
 import com.loopang.route_service.presentation.dto.request.RouteUpdateRequest;
@@ -12,6 +13,7 @@ import com.loopang.route_service.presentation.dto.response.RouteCalculateRespons
 import com.loopang.route_service.presentation.dto.response.RouteDeleteResponse;
 import com.loopang.route_service.presentation.dto.response.RouteResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -30,6 +32,7 @@ public class RouteService {
 
     @Transactional
     public RouteResponse create(RouteCreateRequest request) {
+        // 1차 방어: 동시 요청이 아니면 여기서 400에 가까운 친절한 에러로 끝낸다.
         if (hubRouteRepository.existsByFromHubIdAndToHubId(request.getFromHubId(), request.getToHubId())) {
             throw new DuplicateRouteException();
         }
@@ -42,7 +45,12 @@ public class RouteService {
                 .active(request.getIsActive())
                 .build();
 
-        return RouteResponse.from(hubRouteRepository.save(route));
+        try {
+            // 2차 방어: 동시 요청일 때는 DB 유니크 제약(uk_hub_route_from_to)이 원자적으로 거른다.
+            return RouteResponse.from(hubRouteRepository.save(route));
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicateRouteException();
+        }
     }
 
     public RouteResponse getRoute(UUID routeId) {
@@ -71,7 +79,8 @@ public class RouteService {
     }
 
     public RouteCalculateResponse calculate(RouteCalculateRequest request) {
-        return routeCalculator.calculate(request.getFromHubId(), request.getToHubId());
+        RouteCalculationResult result = routeCalculator.calculate(request.getFromHubId(), request.getToHubId());
+        return RouteCalculateResponse.from(result);
     }
 
     private HubRoute findById(UUID routeId) {

--- a/src/main/java/com/loopang/route_service/application/RouteService.java
+++ b/src/main/java/com/loopang/route_service/application/RouteService.java
@@ -1,0 +1,81 @@
+package com.loopang.route_service.application;
+
+import com.loopang.route_service.domain.entity.HubRoute;
+import com.loopang.route_service.domain.exception.DuplicateRouteException;
+import com.loopang.route_service.domain.exception.RouteNotFoundException;
+import com.loopang.route_service.domain.repository.HubRouteRepository;
+import com.loopang.route_service.domain.service.RouteCalculator;
+import com.loopang.route_service.presentation.dto.request.RouteCalculateRequest;
+import com.loopang.route_service.presentation.dto.request.RouteCreateRequest;
+import com.loopang.route_service.presentation.dto.request.RouteUpdateRequest;
+import com.loopang.route_service.presentation.dto.response.RouteCalculateResponse;
+import com.loopang.route_service.presentation.dto.response.RouteDeleteResponse;
+import com.loopang.route_service.presentation.dto.response.RouteResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RouteService {
+
+    private final HubRouteRepository hubRouteRepository;
+    private final RouteCalculator routeCalculator;
+
+    @Transactional
+    public RouteResponse create(RouteCreateRequest request) {
+        if (hubRouteRepository.existsByFromHubIdAndToHubId(request.getFromHubId(), request.getToHubId())) {
+            throw new DuplicateRouteException();
+        }
+
+        HubRoute route = HubRoute.builder()
+                .fromHubId(request.getFromHubId())
+                .toHubId(request.getToHubId())
+                .distance(request.getDistance())
+                .duration(request.getDuration())
+                .active(request.getIsActive())
+                .build();
+
+        return RouteResponse.from(hubRouteRepository.save(route));
+    }
+
+    public RouteResponse getRoute(UUID routeId) {
+        return RouteResponse.from(findById(routeId));
+    }
+
+    public Page<RouteResponse> getRoutes(Pageable pageable) {
+        return hubRouteRepository.findAll(pageable).map(RouteResponse::from);
+    }
+
+    @Transactional
+    public RouteResponse updateRoute(UUID routeId, RouteUpdateRequest request) {
+        HubRoute route = findById(routeId);
+        route.update(request.getDistance(), request.getDuration(), request.getIsActive());
+        return RouteResponse.from(route);
+    }
+
+    @Transactional
+    public RouteDeleteResponse deleteRoute(UUID routeId) {
+        HubRoute route = findById(routeId);
+        route.delete(null);
+        return RouteDeleteResponse.builder()
+                .routeId(routeId)
+                .deletedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public RouteCalculateResponse calculate(RouteCalculateRequest request) {
+        return routeCalculator.calculate(request.getFromHubId(), request.getToHubId());
+    }
+
+    private HubRoute findById(UUID routeId) {
+        return hubRouteRepository.findById(routeId)
+                .orElseThrow(() -> new RouteNotFoundException(routeId));
+    }
+}

--- a/src/main/java/com/loopang/route_service/application/RouteService.java
+++ b/src/main/java/com/loopang/route_service/application/RouteService.java
@@ -13,7 +13,6 @@ import com.loopang.route_service.presentation.dto.response.RouteCalculateRespons
 import com.loopang.route_service.presentation.dto.response.RouteDeleteResponse;
 import com.loopang.route_service.presentation.dto.response.RouteResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -31,7 +30,10 @@ public class RouteService {
 
     @Transactional
     public RouteResponse create(RouteCreateRequest request) {
-        // 1차 방어: 동시 요청이 아니면 여기서 400에 가까운 친절한 에러로 끝낸다.
+        // @SQLRestriction("deleted_at IS NULL")을 거쳐 "살아 있는" 라우트만 확인한다.
+        // DB 유니크 제약을 걸면 soft-delete된 라우트와 충돌해 (from, to) 재등록이 막히므로 제약은 두지 않는다.
+        // 이 검사는 MASTER 수동 등록 가정 — 동시 요청이 사실상 없는 환경.
+        // TODO: partial unique index(Flyway 도입 시) 또는 복구 플로우로 race condition 방어 강화.
         if (hubRouteRepository.existsByFromHubIdAndToHubId(request.getFromHubId(), request.getToHubId())) {
             throw new DuplicateRouteException();
         }
@@ -44,12 +46,7 @@ public class RouteService {
                 .active(request.getIsActive())
                 .build();
 
-        try {
-            // 2차 방어: 동시 요청일 때는 DB 유니크 제약(uk_hub_route_from_to)이 원자적으로 거른다.
-            return RouteResponse.from(hubRouteRepository.save(route));
-        } catch (DataIntegrityViolationException e) {
-            throw new DuplicateRouteException();
-        }
+        return RouteResponse.from(hubRouteRepository.save(route));
     }
 
     public RouteResponse getRoute(UUID routeId) {

--- a/src/main/java/com/loopang/route_service/application/RouteService.java
+++ b/src/main/java/com/loopang/route_service/application/RouteService.java
@@ -19,7 +19,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
@@ -71,10 +70,10 @@ public class RouteService {
     @Transactional
     public RouteDeleteResponse deleteRoute(UUID routeId) {
         HubRoute route = findById(routeId);
-        route.delete(null);
+        route.delete(null); // TODO: SecurityUtil 전환 후 현재 유저 UUID 전달
         return RouteDeleteResponse.builder()
                 .routeId(routeId)
-                .deletedAt(LocalDateTime.now())
+                .deletedAt(route.getDeletedAt()) // BaseUserEntity.delete()가 세팅한 값을 그대로 사용 — 응답과 DB 값 일치 보장
                 .build();
     }
 

--- a/src/main/java/com/loopang/route_service/domain/entity/HubRoute.java
+++ b/src/main/java/com/loopang/route_service/domain/entity/HubRoute.java
@@ -1,0 +1,82 @@
+package com.loopang.route_service.domain.entity;
+
+import com.loopang.common.domain.BaseUserEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_hub_route")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class HubRoute extends BaseUserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "route_id")
+    private UUID id;
+
+    @Version
+    private int version;
+
+    @Column(name = "from_hub_id", nullable = false)
+    private UUID fromHubId;
+
+    @Column(name = "from_name", length = 100)
+    private String fromName;
+
+    @Column(name = "to_hub_id", nullable = false)
+    private UUID toHubId;
+
+    @Column(name = "to_name", length = 100)
+    private String toName;
+
+    @Column(nullable = false)
+    private Double distance;
+
+    @Column(nullable = false)
+    private Double duration;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+
+    @Column(name = "refreshed_at")
+    private LocalDateTime refreshedAt;
+
+    @Builder
+    public HubRoute(UUID fromHubId, String fromName, UUID toHubId, String toName,
+                    Double distance, Double duration, Boolean active) {
+        if (fromHubId == null) throw new IllegalArgumentException("fromHubId는 필수입니다.");
+        if (toHubId == null) throw new IllegalArgumentException("toHubId는 필수입니다.");
+        if (distance == null || distance < 0) throw new IllegalArgumentException("거리는 0 이상이어야 합니다.");
+        if (duration == null || duration < 0) throw new IllegalArgumentException("시간은 0 이상이어야 합니다.");
+
+        this.fromHubId = fromHubId;
+        this.fromName = fromName;
+        this.toHubId = toHubId;
+        this.toName = toName;
+        this.distance = distance;
+        this.duration = duration;
+        this.active = active != null ? active : (distance <= 150.0);
+    }
+
+    public void update(Double distance, Double duration, Boolean active) {
+        if (distance != null) this.distance = distance;
+        if (duration != null) this.duration = duration;
+        if (active != null) this.active = active;
+    }
+
+    public void refresh(Double distance, Double duration) {
+        this.distance = distance;
+        this.duration = duration;
+        this.active = distance <= 150.0;
+        this.refreshedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/loopang/route_service/domain/entity/HubRoute.java
+++ b/src/main/java/com/loopang/route_service/domain/entity/HubRoute.java
@@ -12,11 +12,19 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
-@Table(name = "p_hub_route")
+@Table(
+        name = "p_hub_route",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_hub_route_from_to",
+                columnNames = {"from_hub_id", "to_hub_id"}
+        )
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("deleted_at IS NULL")
 public class HubRoute extends BaseUserEntity {
+
+    public static final double MAX_ACTIVE_DISTANCE_KM = 150.0;
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -55,6 +63,7 @@ public class HubRoute extends BaseUserEntity {
                     Double distance, Double duration, Boolean active) {
         if (fromHubId == null) throw new IllegalArgumentException("fromHubId는 필수입니다.");
         if (toHubId == null) throw new IllegalArgumentException("toHubId는 필수입니다.");
+        if (fromHubId.equals(toHubId)) throw new IllegalArgumentException("출발 허브와 도착 허브는 같을 수 없습니다.");
         if (distance == null || distance < 0) throw new IllegalArgumentException("거리는 0 이상이어야 합니다.");
         if (duration == null || duration < 0) throw new IllegalArgumentException("시간은 0 이상이어야 합니다.");
 
@@ -64,19 +73,33 @@ public class HubRoute extends BaseUserEntity {
         this.toName = toName;
         this.distance = distance;
         this.duration = duration;
-        this.active = active != null ? active : (distance <= 150.0);
+        // 150km 초과는 무조건 비활성화 — 요청에서 true로 넘어와도 허용 불가
+        boolean withinLimit = distance <= MAX_ACTIVE_DISTANCE_KM;
+        this.active = withinLimit && (active == null || active);
     }
 
     public void update(Double distance, Double duration, Boolean active) {
-        if (distance != null) this.distance = distance;
-        if (duration != null) this.duration = duration;
-        if (active != null) this.active = active;
+        double nextDistance = distance != null ? distance : this.distance;
+        double nextDuration = duration != null ? duration : this.duration;
+
+        if (nextDistance < 0) throw new IllegalArgumentException("거리는 0 이상이어야 합니다.");
+        if (nextDuration < 0) throw new IllegalArgumentException("시간은 0 이상이어야 합니다.");
+
+        this.distance = nextDistance;
+        this.duration = nextDuration;
+        // 거리가 150km를 넘으면 항상 비활성. 그 외엔 명시된 active 값을 따르되, 미지정 시 기존 상태 유지.
+        boolean withinLimit = nextDistance <= MAX_ACTIVE_DISTANCE_KM;
+        boolean nextActive = active == null ? this.active : active;
+        this.active = withinLimit && nextActive;
     }
 
     public void refresh(Double distance, Double duration) {
+        if (distance == null || distance < 0) throw new IllegalArgumentException("거리는 0 이상이어야 합니다.");
+        if (duration == null || duration < 0) throw new IllegalArgumentException("시간은 0 이상이어야 합니다.");
+
         this.distance = distance;
         this.duration = duration;
-        this.active = distance <= 150.0;
+        this.active = distance <= MAX_ACTIVE_DISTANCE_KM;
         this.refreshedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/loopang/route_service/domain/entity/HubRoute.java
+++ b/src/main/java/com/loopang/route_service/domain/entity/HubRoute.java
@@ -12,13 +12,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
-@Table(
-        name = "p_hub_route",
-        uniqueConstraints = @UniqueConstraint(
-                name = "uk_hub_route_from_to",
-                columnNames = {"from_hub_id", "to_hub_id"}
-        )
-)
+@Table(name = "p_hub_route")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("deleted_at IS NULL")

--- a/src/main/java/com/loopang/route_service/domain/exception/DuplicateRouteException.java
+++ b/src/main/java/com/loopang/route_service/domain/exception/DuplicateRouteException.java
@@ -1,0 +1,10 @@
+package com.loopang.route_service.domain.exception;
+
+import com.loopang.common.exception.ConflictException;
+
+public class DuplicateRouteException extends ConflictException {
+
+    public DuplicateRouteException() {
+        super("이미 존재하는 라우트입니다.");
+    }
+}

--- a/src/main/java/com/loopang/route_service/domain/exception/RouteCalculationException.java
+++ b/src/main/java/com/loopang/route_service/domain/exception/RouteCalculationException.java
@@ -1,0 +1,10 @@
+package com.loopang.route_service.domain.exception;
+
+import com.loopang.common.exception.NotFoundException;
+
+public class RouteCalculationException extends NotFoundException {
+
+    public RouteCalculationException() {
+        super("경로를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/loopang/route_service/domain/exception/RouteNotFoundException.java
+++ b/src/main/java/com/loopang/route_service/domain/exception/RouteNotFoundException.java
@@ -1,0 +1,12 @@
+package com.loopang.route_service.domain.exception;
+
+import com.loopang.common.exception.NotFoundException;
+
+import java.util.UUID;
+
+public class RouteNotFoundException extends NotFoundException {
+
+    public RouteNotFoundException(UUID id) {
+        super("라우트를 찾을 수 없습니다. ID: " + id);
+    }
+}

--- a/src/main/java/com/loopang/route_service/domain/repository/HubRouteRepository.java
+++ b/src/main/java/com/loopang/route_service/domain/repository/HubRouteRepository.java
@@ -1,0 +1,24 @@
+package com.loopang.route_service.domain.repository;
+
+import com.loopang.route_service.domain.entity.HubRoute;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface HubRouteRepository {
+
+    HubRoute save(HubRoute hubRoute);
+
+    Optional<HubRoute> findById(UUID id);
+
+    Page<HubRoute> findAll(Pageable pageable);
+
+    List<HubRoute> findAllByActiveTrue();
+
+    Optional<HubRoute> findByFromHubIdAndToHubId(UUID fromHubId, UUID toHubId);
+
+    boolean existsByFromHubIdAndToHubId(UUID fromHubId, UUID toHubId);
+}

--- a/src/main/java/com/loopang/route_service/domain/repository/HubRouteRepository.java
+++ b/src/main/java/com/loopang/route_service/domain/repository/HubRouteRepository.java
@@ -12,6 +12,8 @@ public interface HubRouteRepository {
 
     HubRoute save(HubRoute hubRoute);
 
+    <S extends HubRoute> List<S> saveAll(Iterable<S> entities);
+
     Optional<HubRoute> findById(UUID id);
 
     Page<HubRoute> findAll(Pageable pageable);
@@ -21,4 +23,6 @@ public interface HubRouteRepository {
     Optional<HubRoute> findByFromHubIdAndToHubId(UUID fromHubId, UUID toHubId);
 
     boolean existsByFromHubIdAndToHubId(UUID fromHubId, UUID toHubId);
+
+    long count();
 }

--- a/src/main/java/com/loopang/route_service/domain/service/HubStatusProvider.java
+++ b/src/main/java/com/loopang/route_service/domain/service/HubStatusProvider.java
@@ -1,0 +1,10 @@
+package com.loopang.route_service.domain.service;
+
+import com.loopang.route_service.domain.service.dto.HubStatusData;
+
+import java.util.UUID;
+
+public interface HubStatusProvider {
+
+    HubStatusData getHubStatus(UUID hubId);
+}

--- a/src/main/java/com/loopang/route_service/domain/service/RouteCalculator.java
+++ b/src/main/java/com/loopang/route_service/domain/service/RouteCalculator.java
@@ -1,0 +1,10 @@
+package com.loopang.route_service.domain.service;
+
+import com.loopang.route_service.presentation.dto.response.RouteCalculateResponse;
+
+import java.util.UUID;
+
+public interface RouteCalculator {
+
+    RouteCalculateResponse calculate(UUID fromHubId, UUID toHubId);
+}

--- a/src/main/java/com/loopang/route_service/domain/service/RouteCalculator.java
+++ b/src/main/java/com/loopang/route_service/domain/service/RouteCalculator.java
@@ -1,10 +1,10 @@
 package com.loopang.route_service.domain.service;
 
-import com.loopang.route_service.presentation.dto.response.RouteCalculateResponse;
+import com.loopang.route_service.domain.service.dto.RouteCalculationResult;
 
 import java.util.UUID;
 
 public interface RouteCalculator {
 
-    RouteCalculateResponse calculate(UUID fromHubId, UUID toHubId);
+    RouteCalculationResult calculate(UUID fromHubId, UUID toHubId);
 }

--- a/src/main/java/com/loopang/route_service/domain/service/TMapProvider.java
+++ b/src/main/java/com/loopang/route_service/domain/service/TMapProvider.java
@@ -1,0 +1,8 @@
+package com.loopang.route_service.domain.service;
+
+public interface TMapProvider {
+
+    TMapRouteResult getRoute(double fromLat, double fromLon, double toLat, double toLon);
+
+    record TMapRouteResult(double distanceKm, double durationMin) {}
+}

--- a/src/main/java/com/loopang/route_service/domain/service/dto/HubData.java
+++ b/src/main/java/com/loopang/route_service/domain/service/dto/HubData.java
@@ -1,0 +1,10 @@
+package com.loopang.route_service.domain.service.dto;
+
+import java.util.UUID;
+
+public record HubData(
+        UUID hubId,
+        String name,
+        Double latitude,
+        Double longitude
+) {}

--- a/src/main/java/com/loopang/route_service/domain/service/dto/HubStatusData.java
+++ b/src/main/java/com/loopang/route_service/domain/service/dto/HubStatusData.java
@@ -1,0 +1,9 @@
+package com.loopang.route_service.domain.service.dto;
+
+import java.util.UUID;
+
+public record HubStatusData(
+        UUID hubId,
+        String name,
+        String status
+) {}

--- a/src/main/java/com/loopang/route_service/domain/service/dto/RouteCalculationResult.java
+++ b/src/main/java/com/loopang/route_service/domain/service/dto/RouteCalculationResult.java
@@ -1,0 +1,33 @@
+package com.loopang.route_service.domain.service.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 경로 계산 결과 — 도메인/애플리케이션 계층용 순수 모델.
+ * presentation 계층에서 RouteCalculateResponse로 매핑된다.
+ */
+@Builder
+public record RouteCalculationResult(
+        UUID fromHubId,
+        UUID toHubId,
+        List<PathNode> path,
+        List<RouteEdge> routeEdges,
+        double totalDistance,
+        double totalDuration
+) {
+
+    @Builder
+    public record PathNode(int sequence, UUID hubId) {}
+
+    @Builder
+    public record RouteEdge(
+            int sequence,
+            UUID fromHubId,
+            UUID toHubId,
+            double distance,
+            double duration
+    ) {}
+}

--- a/src/main/java/com/loopang/route_service/infrastructure/client/HubFeignClient.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/client/HubFeignClient.java
@@ -1,0 +1,22 @@
+package com.loopang.route_service.infrastructure.client;
+
+import com.loopang.route_service.domain.service.dto.HubData;
+import com.loopang.route_service.domain.service.dto.HubStatusData;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+import java.util.UUID;
+
+@FeignClient(name = "hub-service")
+public interface HubFeignClient {
+
+    @GetMapping("/api/hubs/{hubId}")
+    HubStatusData getHub(@PathVariable("hubId") UUID hubId);
+
+    @GetMapping("/api/hubs?size=50")
+    HubListResponse getHubs();
+
+    record HubListResponse(List<HubData> data) {}
+}

--- a/src/main/java/com/loopang/route_service/infrastructure/client/HubStatusProviderImpl.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/client/HubStatusProviderImpl.java
@@ -1,0 +1,27 @@
+package com.loopang.route_service.infrastructure.client;
+
+import com.loopang.route_service.domain.service.HubStatusProvider;
+import com.loopang.route_service.domain.service.dto.HubStatusData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HubStatusProviderImpl implements HubStatusProvider {
+
+    private final HubFeignClient hubFeignClient;
+
+    @Override
+    public HubStatusData getHubStatus(UUID hubId) {
+        try {
+            return hubFeignClient.getHub(hubId);
+        } catch (Exception e) {
+            log.warn("[HubStatus] 허브 상태 조회 실패, 기본값(NORMAL) 사용: hubId={}", hubId);
+            return new HubStatusData(hubId, "", "정상");
+        }
+    }
+}

--- a/src/main/java/com/loopang/route_service/infrastructure/init/HubRouteInitializer.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/init/HubRouteInitializer.java
@@ -1,0 +1,87 @@
+package com.loopang.route_service.infrastructure.init;
+
+import com.loopang.route_service.domain.entity.HubRoute;
+import com.loopang.route_service.domain.repository.HubRouteRepository;
+import com.loopang.route_service.domain.service.dto.HubData;
+import com.loopang.route_service.infrastructure.client.HubFeignClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HubRouteInitializer implements ApplicationRunner {
+
+    private final HubRouteRepository hubRouteRepository;
+    private final HubFeignClient hubFeignClient;
+
+    private static final double MAX_ACTIVE_DISTANCE = 150.0;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (hubRouteRepository.findAllByActiveTrue().size() > 0) {
+            log.info("[HubRouteInitializer] 이미 초기 데이터 존재 — 스킵");
+            return;
+        }
+
+        List<HubData> hubs;
+        try {
+            HubFeignClient.HubListResponse response = hubFeignClient.getHubs();
+            hubs = response.data();
+        } catch (Exception e) {
+            log.warn("[HubRouteInitializer] Hub Service 연결 실패 — 초기 데이터 생성 스킵. 나중에 Hub Service 시작 후 재시작 필요.");
+            return;
+        }
+
+        if (hubs == null || hubs.isEmpty()) {
+            log.warn("[HubRouteInitializer] 허브 데이터 없음 — 스킵");
+            return;
+        }
+
+        log.info("[HubRouteInitializer] {}개 허브 간 라우트 초기화 시작", hubs.size());
+        int count = 0;
+
+        for (int i = 0; i < hubs.size(); i++) {
+            for (int j = 0; j < hubs.size(); j++) {
+                if (i == j) continue;
+
+                HubData from = hubs.get(i);
+                HubData to = hubs.get(j);
+
+                double distance = haversine(from.latitude(), from.longitude(), to.latitude(), to.longitude());
+                double duration = distance / 60.0 * 60;
+
+                HubRoute route = HubRoute.builder()
+                        .fromHubId(from.hubId())
+                        .fromName(from.name())
+                        .toHubId(to.hubId())
+                        .toName(to.name())
+                        .distance(Math.round(distance * 10) / 10.0)
+                        .duration(Math.round(duration * 10) / 10.0)
+                        .active(distance <= MAX_ACTIVE_DISTANCE)
+                        .build();
+
+                hubRouteRepository.save(route);
+                count++;
+            }
+        }
+
+        log.info("[HubRouteInitializer] 초기화 완료: {}개 라우트 생성", count);
+    }
+
+    private double haversine(double lat1, double lon1, double lat2, double lon2) {
+        double R = 6371.0;
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c;
+    }
+}

--- a/src/main/java/com/loopang/route_service/infrastructure/init/HubRouteInitializer.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/init/HubRouteInitializer.java
@@ -9,7 +9,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -20,11 +22,12 @@ public class HubRouteInitializer implements ApplicationRunner {
     private final HubRouteRepository hubRouteRepository;
     private final HubFeignClient hubFeignClient;
 
-    private static final double MAX_ACTIVE_DISTANCE = 150.0;
-
     @Override
+    @Transactional
     public void run(ApplicationArguments args) {
-        if (hubRouteRepository.findAllByActiveTrue().size() > 0) {
+        // active 여부가 아니라 "라우트가 하나라도 있는지"로 판단.
+        // TMap 갱신으로 전부 비활성화돼도 재생성되지 않도록.
+        if (hubRouteRepository.count() > 0) {
             log.info("[HubRouteInitializer] 이미 초기 데이터 존재 — 스킵");
             return;
         }
@@ -44,8 +47,8 @@ public class HubRouteInitializer implements ApplicationRunner {
         }
 
         log.info("[HubRouteInitializer] {}개 허브 간 라우트 초기화 시작", hubs.size());
-        int count = 0;
 
+        List<HubRoute> routes = new ArrayList<>(hubs.size() * (hubs.size() - 1));
         for (int i = 0; i < hubs.size(); i++) {
             for (int j = 0; j < hubs.size(); j++) {
                 if (i == j) continue;
@@ -54,24 +57,24 @@ public class HubRouteInitializer implements ApplicationRunner {
                 HubData to = hubs.get(j);
 
                 double distance = haversine(from.latitude(), from.longitude(), to.latitude(), to.longitude());
-                double duration = distance / 60.0 * 60;
+                // 60km/h 평균 속도 가정 → distance(km) / 60 * 60(min)
+                double duration = distance;
 
-                HubRoute route = HubRoute.builder()
+                routes.add(HubRoute.builder()
                         .fromHubId(from.hubId())
                         .fromName(from.name())
                         .toHubId(to.hubId())
                         .toName(to.name())
                         .distance(Math.round(distance * 10) / 10.0)
                         .duration(Math.round(duration * 10) / 10.0)
-                        .active(distance <= MAX_ACTIVE_DISTANCE)
-                        .build();
-
-                hubRouteRepository.save(route);
-                count++;
+                        // active는 HubRoute 생성자에서 150km 규칙으로 자동 결정
+                        .build());
             }
         }
 
-        log.info("[HubRouteInitializer] 초기화 완료: {}개 라우트 생성", count);
+        // 한 트랜잭션에 한 번의 저장 — 중간 실패 시 전부 롤백돼 부분 초기화가 고착되지 않는다.
+        hubRouteRepository.saveAll(routes);
+        log.info("[HubRouteInitializer] 초기화 완료: {}개 라우트 생성", routes.size());
     }
 
     private double haversine(double lat1, double lon1, double lat2, double lon2) {

--- a/src/main/java/com/loopang/route_service/infrastructure/init/HubRouteInitializer.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/init/HubRouteInitializer.java
@@ -49,12 +49,22 @@ public class HubRouteInitializer implements ApplicationRunner {
         log.info("[HubRouteInitializer] {}개 허브 간 라우트 초기화 시작", hubs.size());
 
         List<HubRoute> routes = new ArrayList<>(hubs.size() * (hubs.size() - 1));
+        int skipped = 0;
         for (int i = 0; i < hubs.size(); i++) {
             for (int j = 0; j < hubs.size(); j++) {
                 if (i == j) continue;
 
                 HubData from = hubs.get(i);
                 HubData to = hubs.get(j);
+
+                // Hub Service 응답에 null 좌표/ID가 섞여 있어도 전체 초기화가 NPE로 죽지 않도록 방어.
+                if (!hasValidCoordinates(from) || !hasValidCoordinates(to)) {
+                    log.warn("[HubRouteInitializer] 좌표/ID 누락 허브 스킵: {} → {}",
+                            from == null ? "null" : from.name(),
+                            to == null ? "null" : to.name());
+                    skipped++;
+                    continue;
+                }
 
                 double distance = haversine(from.latitude(), from.longitude(), to.latitude(), to.longitude());
                 // 60km/h 평균 속도 가정 → distance(km) / 60 * 60(min)
@@ -72,9 +82,20 @@ public class HubRouteInitializer implements ApplicationRunner {
             }
         }
 
+        if (skipped > 0) {
+            log.warn("[HubRouteInitializer] 좌표 누락으로 {}쌍 스킵됨", skipped);
+        }
+
         // 한 트랜잭션에 한 번의 저장 — 중간 실패 시 전부 롤백돼 부분 초기화가 고착되지 않는다.
         hubRouteRepository.saveAll(routes);
         log.info("[HubRouteInitializer] 초기화 완료: {}개 라우트 생성", routes.size());
+    }
+
+    private boolean hasValidCoordinates(HubData hub) {
+        return hub != null
+                && hub.hubId() != null
+                && hub.latitude() != null
+                && hub.longitude() != null;
     }
 
     private double haversine(double lat1, double lon1, double lat2, double lon2) {

--- a/src/main/java/com/loopang/route_service/infrastructure/persistence/JpaHubRouteRepository.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/persistence/JpaHubRouteRepository.java
@@ -1,0 +1,10 @@
+package com.loopang.route_service.infrastructure.persistence;
+
+import com.loopang.route_service.domain.entity.HubRoute;
+import com.loopang.route_service.domain.repository.HubRouteRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface JpaHubRouteRepository extends JpaRepository<HubRoute, UUID>, HubRouteRepository {
+}

--- a/src/main/java/com/loopang/route_service/infrastructure/route/DijkstraRouteCalculator.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/route/DijkstraRouteCalculator.java
@@ -1,0 +1,134 @@
+package com.loopang.route_service.infrastructure.route;
+
+import com.loopang.route_service.domain.entity.HubRoute;
+import com.loopang.route_service.domain.exception.RouteCalculationException;
+import com.loopang.route_service.domain.repository.HubRouteRepository;
+import com.loopang.route_service.domain.service.HubStatusProvider;
+import com.loopang.route_service.domain.service.RouteCalculator;
+import com.loopang.route_service.domain.service.dto.HubStatusData;
+import com.loopang.route_service.presentation.dto.response.RouteCalculateResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DijkstraRouteCalculator implements RouteCalculator {
+
+    private final HubRouteRepository hubRouteRepository;
+    private final HubStatusProvider hubStatusProvider;
+
+    // 혼잡도 가중 계수
+    private static final double BUSY_WEIGHT = 0.8;   // 거리 80% 가중
+    private static final double FULL_WEIGHT = 2.0;    // 거리 200% 가중
+
+    @Override
+    public RouteCalculateResponse calculate(UUID fromHubId, UUID toHubId) {
+        List<HubRoute> activeRoutes = hubRouteRepository.findAllByActiveTrue();
+
+        // 허브 상태 캐시 (같은 계산 내 중복 호출 방지)
+        Map<UUID, String> hubStatusCache = new HashMap<>();
+
+        // 인접 리스트 구성
+        Map<UUID, List<HubRoute>> graph = new HashMap<>();
+        for (HubRoute route : activeRoutes) {
+            graph.computeIfAbsent(route.getFromHubId(), k -> new ArrayList<>()).add(route);
+        }
+
+        // 다익스트라
+        Map<UUID, Double> dist = new HashMap<>();
+        Map<UUID, UUID> prev = new HashMap<>();
+        Map<String, HubRoute> edgeMap = new HashMap<>();
+        PriorityQueue<UUID> pq = new PriorityQueue<>(Comparator.comparingDouble(dist::get));
+
+        dist.put(fromHubId, 0.0);
+        pq.add(fromHubId);
+
+        while (!pq.isEmpty()) {
+            UUID current = pq.poll();
+            double currentDist = dist.get(current);
+
+            if (current.equals(toHubId)) break;
+
+            List<HubRoute> neighbors = graph.getOrDefault(current, Collections.emptyList());
+            for (HubRoute route : neighbors) {
+                UUID next = route.getToHubId();
+
+                // 혼잡도 가중 비용 계산
+                double congestionWeight = getCongestionWeight(next, hubStatusCache);
+                double weightedDistance = route.getDistance() * (1 + congestionWeight);
+
+                double newDist = currentDist + weightedDistance;
+
+                if (!dist.containsKey(next) || newDist < dist.get(next)) {
+                    dist.put(next, newDist);
+                    prev.put(next, current);
+                    edgeMap.put(current + "->" + next, route);
+                    pq.add(next);
+                }
+            }
+        }
+
+        if (!dist.containsKey(toHubId)) {
+            throw new RouteCalculationException();
+        }
+
+        // 경로 역추적
+        List<UUID> path = new ArrayList<>();
+        UUID current = toHubId;
+        while (current != null) {
+            path.add(0, current);
+            current = prev.get(current);
+        }
+
+        // 응답 구성 (실제 거리/시간은 원본 값)
+        List<RouteCalculateResponse.PathNode> pathNodes = new ArrayList<>();
+        for (int i = 0; i < path.size(); i++) {
+            pathNodes.add(RouteCalculateResponse.PathNode.builder()
+                    .sequence(i + 1)
+                    .hubId(path.get(i))
+                    .build());
+        }
+
+        List<RouteCalculateResponse.RouteEdge> routeEdges = new ArrayList<>();
+        double totalDistance = 0;
+        double totalDuration = 0;
+        for (int i = 0; i < path.size() - 1; i++) {
+            HubRoute edge = edgeMap.get(path.get(i) + "->" + path.get(i + 1));
+            routeEdges.add(RouteCalculateResponse.RouteEdge.builder()
+                    .sequence(i + 1)
+                    .fromHubId(edge.getFromHubId())
+                    .toHubId(edge.getToHubId())
+                    .distance(edge.getDistance())
+                    .duration(edge.getDuration())
+                    .build());
+            totalDistance += edge.getDistance();
+            totalDuration += edge.getDuration();
+        }
+
+        return RouteCalculateResponse.builder()
+                .fromHubId(fromHubId)
+                .toHubId(toHubId)
+                .path(pathNodes)
+                .routeEdges(routeEdges)
+                .totalDistance(totalDistance)
+                .totalDuration(totalDuration)
+                .build();
+    }
+
+    private double getCongestionWeight(UUID hubId, Map<UUID, String> cache) {
+        String status = cache.computeIfAbsent(hubId, id -> {
+            HubStatusData data = hubStatusProvider.getHubStatus(id);
+            return data.status();
+        });
+
+        return switch (status) {
+            case "혼잡" -> BUSY_WEIGHT;
+            case "만원" -> FULL_WEIGHT;
+            default -> 0.0; // 정상
+        };
+    }
+}

--- a/src/main/java/com/loopang/route_service/infrastructure/route/DijkstraRouteCalculator.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/route/DijkstraRouteCalculator.java
@@ -6,7 +6,7 @@ import com.loopang.route_service.domain.repository.HubRouteRepository;
 import com.loopang.route_service.domain.service.HubStatusProvider;
 import com.loopang.route_service.domain.service.RouteCalculator;
 import com.loopang.route_service.domain.service.dto.HubStatusData;
-import com.loopang.route_service.presentation.dto.response.RouteCalculateResponse;
+import com.loopang.route_service.domain.service.dto.RouteCalculationResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -26,7 +26,7 @@ public class DijkstraRouteCalculator implements RouteCalculator {
     private static final double FULL_WEIGHT = 2.0;    // 거리 200% 가중
 
     @Override
-    public RouteCalculateResponse calculate(UUID fromHubId, UUID toHubId) {
+    public RouteCalculationResult calculate(UUID fromHubId, UUID toHubId) {
         List<HubRoute> activeRoutes = hubRouteRepository.findAllByActiveTrue();
 
         // 허브 상태 캐시 (같은 계산 내 중복 호출 방지)
@@ -85,20 +85,20 @@ public class DijkstraRouteCalculator implements RouteCalculator {
         }
 
         // 응답 구성 (실제 거리/시간은 원본 값)
-        List<RouteCalculateResponse.PathNode> pathNodes = new ArrayList<>();
+        List<RouteCalculationResult.PathNode> pathNodes = new ArrayList<>();
         for (int i = 0; i < path.size(); i++) {
-            pathNodes.add(RouteCalculateResponse.PathNode.builder()
+            pathNodes.add(RouteCalculationResult.PathNode.builder()
                     .sequence(i + 1)
                     .hubId(path.get(i))
                     .build());
         }
 
-        List<RouteCalculateResponse.RouteEdge> routeEdges = new ArrayList<>();
+        List<RouteCalculationResult.RouteEdge> routeEdges = new ArrayList<>();
         double totalDistance = 0;
         double totalDuration = 0;
         for (int i = 0; i < path.size() - 1; i++) {
             HubRoute edge = edgeMap.get(path.get(i) + "->" + path.get(i + 1));
-            routeEdges.add(RouteCalculateResponse.RouteEdge.builder()
+            routeEdges.add(RouteCalculationResult.RouteEdge.builder()
                     .sequence(i + 1)
                     .fromHubId(edge.getFromHubId())
                     .toHubId(edge.getToHubId())
@@ -109,7 +109,7 @@ public class DijkstraRouteCalculator implements RouteCalculator {
             totalDuration += edge.getDuration();
         }
 
-        return RouteCalculateResponse.builder()
+        return RouteCalculationResult.builder()
                 .fromHubId(fromHubId)
                 .toHubId(toHubId)
                 .path(pathNodes)

--- a/src/main/java/com/loopang/route_service/infrastructure/scheduler/TMapRefreshScheduler.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/scheduler/TMapRefreshScheduler.java
@@ -1,0 +1,76 @@
+package com.loopang.route_service.infrastructure.scheduler;
+
+import com.loopang.route_service.domain.entity.HubRoute;
+import com.loopang.route_service.domain.repository.HubRouteRepository;
+import com.loopang.route_service.domain.service.TMapProvider;
+import com.loopang.route_service.domain.service.dto.HubData;
+import com.loopang.route_service.infrastructure.client.HubFeignClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TMapRefreshScheduler {
+
+    private final HubRouteRepository hubRouteRepository;
+    private final TMapProvider tMapProvider;
+    private final HubFeignClient hubFeignClient;
+
+    @Scheduled(fixedDelay = 3600000) // 1시간
+    @Transactional
+    public void refresh() {
+        log.info("[TMapRefresh] 허브 라우트 갱신 시작");
+
+        // Hub Service에서 허브 좌표 조회
+        Map<UUID, double[]> hubCoords = new HashMap<>();
+        try {
+            HubFeignClient.HubListResponse response = hubFeignClient.getHubs();
+            List<HubData> hubs = response.data();
+            for (HubData hub : hubs) {
+                hubCoords.put(hub.hubId(), new double[]{hub.latitude(), hub.longitude()});
+            }
+        } catch (Exception e) {
+            log.error("[TMapRefresh] Hub Service 연결 실패 — 갱신 스킵");
+            return;
+        }
+
+        Page<HubRoute> routes = hubRouteRepository.findAll(PageRequest.of(0, 300));
+        int updated = 0;
+        int failed = 0;
+
+        for (HubRoute route : routes) {
+            double[] from = hubCoords.get(route.getFromHubId());
+            double[] to = hubCoords.get(route.getToHubId());
+
+            if (from == null || to == null) {
+                log.warn("[TMapRefresh] 좌표 없음: {} → {}", route.getFromHubId(), route.getToHubId());
+                failed++;
+                continue;
+            }
+
+            TMapProvider.TMapRouteResult result = tMapProvider.getRoute(from[0], from[1], to[0], to[1]);
+
+            if (result != null) {
+                route.refresh(result.distanceKm(), result.durationMin());
+                updated++;
+            } else {
+                failed++;
+            }
+
+            try { Thread.sleep(200); } catch (InterruptedException ignored) {}
+        }
+
+        log.info("[TMapRefresh] 갱신 완료: 성공 {}, 실패 {}", updated, failed);
+    }
+}

--- a/src/main/java/com/loopang/route_service/infrastructure/scheduler/TMapRefreshScheduler.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/scheduler/TMapRefreshScheduler.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,54 +24,110 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class TMapRefreshScheduler {
 
+    private static final int PAGE_SIZE = 100;
+    private static final long CALL_DELAY_MS = 200L;
+
     private final HubRouteRepository hubRouteRepository;
     private final TMapProvider tMapProvider;
     private final HubFeignClient hubFeignClient;
+    private final TMapRouteUpdater routeUpdater;
 
     @Scheduled(fixedDelay = 3600000) // 1시간
-    @Transactional
     public void refresh() {
         log.info("[TMapRefresh] 허브 라우트 갱신 시작");
 
-        // Hub Service에서 허브 좌표 조회
-        Map<UUID, double[]> hubCoords = new HashMap<>();
+        // 1. Hub Service에서 허브 좌표 조회 (트랜잭션 밖)
+        Map<UUID, double[]> hubCoords;
         try {
             HubFeignClient.HubListResponse response = hubFeignClient.getHubs();
             List<HubData> hubs = response.data();
+            hubCoords = new HashMap<>(hubs.size());
             for (HubData hub : hubs) {
                 hubCoords.put(hub.hubId(), new double[]{hub.latitude(), hub.longitude()});
             }
         } catch (Exception e) {
-            log.error("[TMapRefresh] Hub Service 연결 실패 — 갱신 스킵");
+            log.error("[TMapRefresh] Hub Service 연결 실패 — 갱신 스킵", e);
             return;
         }
 
-        Page<HubRoute> routes = hubRouteRepository.findAll(PageRequest.of(0, 300));
         int updated = 0;
         int failed = 0;
 
-        for (HubRoute route : routes) {
-            double[] from = hubCoords.get(route.getFromHubId());
-            double[] to = hubCoords.get(route.getToHubId());
+        // 2. 모든 페이지를 순회 (첫 300건만 보는 버그 방지)
+        int pageNumber = 0;
+        boolean interrupted = false;
 
-            if (from == null || to == null) {
-                log.warn("[TMapRefresh] 좌표 없음: {} → {}", route.getFromHubId(), route.getToHubId());
-                failed++;
-                continue;
+        while (!interrupted) {
+            Pageable pageable = PageRequest.of(pageNumber, PAGE_SIZE);
+            Page<HubRoute> routes = routeUpdater.loadPage(pageable);
+
+            if (routes.isEmpty()) {
+                break;
             }
 
-            TMapProvider.TMapRouteResult result = tMapProvider.getRoute(from[0], from[1], to[0], to[1]);
+            for (HubRoute route : routes) {
+                double[] from = hubCoords.get(route.getFromHubId());
+                double[] to = hubCoords.get(route.getToHubId());
 
-            if (result != null) {
-                route.refresh(result.distanceKm(), result.durationMin());
-                updated++;
-            } else {
-                failed++;
+                if (from == null || to == null) {
+                    log.warn("[TMapRefresh] 좌표 없음: {} → {}", route.getFromHubId(), route.getToHubId());
+                    failed++;
+                    continue;
+                }
+
+                // TMap 외부 호출은 트랜잭션 밖에서 수행
+                TMapProvider.TMapRouteResult result = tMapProvider.getRoute(from[0], from[1], to[0], to[1]);
+
+                if (result == null) {
+                    failed++;
+                } else {
+                    // 저장만 짧은 단건 트랜잭션으로 분리
+                    try {
+                        routeUpdater.applyRefresh(route.getId(), result.distanceKm(), result.durationMin());
+                        updated++;
+                    } catch (Exception e) {
+                        log.warn("[TMapRefresh] 라우트 저장 실패: routeId={}", route.getId(), e);
+                        failed++;
+                    }
+                }
+
+                // rate limit 대기 — 인터럽트 시 깔끔하게 종료
+                try {
+                    Thread.sleep(CALL_DELAY_MS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.warn("[TMapRefresh] 인터럽트 수신 — 갱신 중단");
+                    interrupted = true;
+                    break;
+                }
             }
 
-            try { Thread.sleep(200); } catch (InterruptedException ignored) {}
+            if (routes.isLast()) break;
+            pageNumber++;
         }
 
         log.info("[TMapRefresh] 갱신 완료: 성공 {}, 실패 {}", updated, failed);
+    }
+
+    /**
+     * 스케줄러 메서드 내부에서 @Transactional 메서드를 프록시 경유로 호출하기 위한 별도 컴포넌트.
+     * 페이지 로드/단건 저장 각각을 짧은 트랜잭션으로 분리한다.
+     */
+    @Component
+    @RequiredArgsConstructor
+    static class TMapRouteUpdater {
+
+        private final HubRouteRepository hubRouteRepository;
+
+        @Transactional(readOnly = true)
+        public Page<HubRoute> loadPage(Pageable pageable) {
+            return hubRouteRepository.findAll(pageable);
+        }
+
+        @Transactional
+        public void applyRefresh(UUID routeId, double distanceKm, double durationMin) {
+            hubRouteRepository.findById(routeId)
+                    .ifPresent(route -> route.refresh(distanceKm, durationMin));
+        }
     }
 }

--- a/src/main/java/com/loopang/route_service/infrastructure/tmap/TMapProperties.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/tmap/TMapProperties.java
@@ -1,0 +1,19 @@
+package com.loopang.route_service.infrastructure.tmap;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Component
+@Validated
+@ConfigurationProperties(prefix = "tmap")
+public class TMapProperties {
+
+    @NotBlank(message = "tmap.api-key는 필수입니다.")
+    private String apiKey;
+}

--- a/src/main/java/com/loopang/route_service/infrastructure/tmap/TMapProviderImpl.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/tmap/TMapProviderImpl.java
@@ -1,23 +1,30 @@
 package com.loopang.route_service.infrastructure.tmap;
 
 import com.loopang.route_service.domain.service.TMapProvider;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class TMapProviderImpl implements TMapProvider {
 
     private static final String TMAP_API_URL = "https://apis.openapi.sk.com/tmap/routes?version=1";
 
     private final TMapProperties properties;
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
+
+    public TMapProviderImpl(TMapProperties properties,
+                            @Qualifier("tmapRestTemplate") RestTemplate restTemplate) {
+        this.properties = properties;
+        this.restTemplate = restTemplate;
+    }
 
     @Override
     public TMapRouteResult getRoute(double fromLat, double fromLon, double toLat, double toLon) {
@@ -36,6 +43,7 @@ public class TMapProviderImpl implements TMapProvider {
         );
 
         try {
+            @SuppressWarnings("rawtypes")
             ResponseEntity<Map> response = restTemplate.exchange(
                     TMAP_API_URL,
                     HttpMethod.POST,
@@ -43,30 +51,40 @@ public class TMapProviderImpl implements TMapProvider {
                     Map.class
             );
 
-            Map responseBody = response.getBody();
+            Map<?, ?> responseBody = response.getBody();
             if (responseBody == null) {
                 log.error("[TMap] 응답 없음");
                 return null;
             }
 
-            Map features = (Map) ((java.util.List) responseBody.get("features")).get(0);
-            Map prop = (Map) features.get("properties");
+            List<?> features = (List<?>) responseBody.get("features");
+            if (features == null || features.isEmpty()) {
+                log.error("[TMap] features 비어있음");
+                return null;
+            }
 
-            int totalDistanceM = (int) prop.get("totalDistance");
-            int totalTimeSec = (int) prop.get("totalTime");
+            Map<?, ?> firstFeature = (Map<?, ?>) features.get(0);
+            Map<?, ?> prop = (Map<?, ?>) firstFeature.get("properties");
+
+            int totalDistanceM = ((Number) prop.get("totalDistance")).intValue();
+            int totalTimeSec = ((Number) prop.get("totalTime")).intValue();
 
             double distanceKm = totalDistanceM / 1000.0;
             double durationMin = totalTimeSec / 60.0;
 
-            log.debug("[TMap] ({},{}) → ({},{}) = {:.1f}km, {:.1f}min",
+            log.debug("[TMap] ({},{}) → ({},{}) = {}km, {}min",
                     fromLat, fromLon, toLat, toLon, distanceKm, durationMin);
 
             return new TMapRouteResult(
                     Math.round(distanceKm * 10) / 10.0,
                     Math.round(durationMin * 10) / 10.0
             );
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             log.error("[TMap] API 호출 실패: ({},{}) → ({},{}): {}",
+                    fromLat, fromLon, toLat, toLon, e.getMessage());
+            return null;
+        } catch (Exception e) {
+            log.error("[TMap] 응답 파싱 실패: ({},{}) → ({},{}): {}",
                     fromLat, fromLon, toLat, toLon, e.getMessage());
             return null;
         }

--- a/src/main/java/com/loopang/route_service/infrastructure/tmap/TMapProviderImpl.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/tmap/TMapProviderImpl.java
@@ -1,0 +1,74 @@
+package com.loopang.route_service.infrastructure.tmap;
+
+import com.loopang.route_service.domain.service.TMapProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TMapProviderImpl implements TMapProvider {
+
+    private static final String TMAP_API_URL = "https://apis.openapi.sk.com/tmap/routes?version=1";
+
+    private final TMapProperties properties;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Override
+    public TMapRouteResult getRoute(double fromLat, double fromLon, double toLat, double toLon) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("appKey", properties.getApiKey());
+
+        Map<String, Object> body = Map.of(
+                "startX", String.valueOf(fromLon),
+                "startY", String.valueOf(fromLat),
+                "endX", String.valueOf(toLon),
+                "endY", String.valueOf(toLat),
+                "reqCoordType", "WGS84GEO",
+                "resCoordType", "WGS84GEO",
+                "searchOption", "0"
+        );
+
+        try {
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    TMAP_API_URL,
+                    HttpMethod.POST,
+                    new HttpEntity<>(body, headers),
+                    Map.class
+            );
+
+            Map responseBody = response.getBody();
+            if (responseBody == null) {
+                log.error("[TMap] 응답 없음");
+                return null;
+            }
+
+            Map features = (Map) ((java.util.List) responseBody.get("features")).get(0);
+            Map prop = (Map) features.get("properties");
+
+            int totalDistanceM = (int) prop.get("totalDistance");
+            int totalTimeSec = (int) prop.get("totalTime");
+
+            double distanceKm = totalDistanceM / 1000.0;
+            double durationMin = totalTimeSec / 60.0;
+
+            log.debug("[TMap] ({},{}) → ({},{}) = {:.1f}km, {:.1f}min",
+                    fromLat, fromLon, toLat, toLon, distanceKm, durationMin);
+
+            return new TMapRouteResult(
+                    Math.round(distanceKm * 10) / 10.0,
+                    Math.round(durationMin * 10) / 10.0
+            );
+        } catch (Exception e) {
+            log.error("[TMap] API 호출 실패: ({},{}) → ({},{}): {}",
+                    fromLat, fromLon, toLat, toLon, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/loopang/route_service/infrastructure/tmap/TMapRestTemplateConfig.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/tmap/TMapRestTemplateConfig.java
@@ -1,0 +1,23 @@
+package com.loopang.route_service.infrastructure.tmap;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class TMapRestTemplateConfig {
+
+    /**
+     * TMap 전용 RestTemplate. 스케줄러 스레드가 무한정 블로킹되지 않도록 timeout을 명시적으로 설정.
+     */
+    @Bean
+    public RestTemplate tmapRestTemplate(RestTemplateBuilder builder) {
+        return builder
+                .connectTimeout(Duration.ofSeconds(3))
+                .readTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+}

--- a/src/main/java/com/loopang/route_service/presentation/RouteController.java
+++ b/src/main/java/com/loopang/route_service/presentation/RouteController.java
@@ -70,7 +70,18 @@ public class RouteController {
         return CommonResponse.success(routeService.calculate(request), "허브 경로 계산에 성공했습니다.");
     }
 
+    /**
+     * MASTER 권한 검증.
+     *
+     * <p>현재는 Gateway가 Keycloak JWT를 검증한 뒤 주입하는 X-User-Role 헤더를 그대로 신뢰한다.
+     * 네트워크 경계(Gateway 경유만 허용)에 방어를 둔 전제로 동작하며,
+     * 장기적으로는 common 라이브러리의 {@code SecurityUtil} / {@code @PreAuthorize}로 전환 예정
+     * (common Phase 4, 전 서비스 일괄 — 현재는 hub/user-service와 같은 패턴 유지).
+     */
     private void checkMaster(String userRole) {
+        if (userRole == null || userRole.isBlank()) {
+            throw new ForbiddenException("인증 정보가 없습니다.");
+        }
         if (!"ROLE_MASTER".equals(userRole)) {
             throw new ForbiddenException("마스터 관리자만 수행할 수 있는 작업입니다.");
         }

--- a/src/main/java/com/loopang/route_service/presentation/RouteController.java
+++ b/src/main/java/com/loopang/route_service/presentation/RouteController.java
@@ -1,0 +1,78 @@
+package com.loopang.route_service.presentation;
+
+import com.loopang.common.exception.ForbiddenException;
+import com.loopang.common.response.CommonResponse;
+import com.loopang.common.response.PageInfo;
+import com.loopang.route_service.application.RouteService;
+import com.loopang.route_service.presentation.dto.request.RouteCalculateRequest;
+import com.loopang.route_service.presentation.dto.request.RouteCreateRequest;
+import com.loopang.route_service.presentation.dto.request.RouteUpdateRequest;
+import com.loopang.route_service.presentation.dto.response.RouteCalculateResponse;
+import com.loopang.route_service.presentation.dto.response.RouteDeleteResponse;
+import com.loopang.route_service.presentation.dto.response.RouteResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/hub-routes")
+@RequiredArgsConstructor
+public class RouteController {
+
+    private final RouteService routeService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommonResponse<RouteResponse> create(
+            @RequestHeader("X-User-Role") String userRole,
+            @Valid @RequestBody RouteCreateRequest request) {
+        checkMaster(userRole);
+        return CommonResponse.success(routeService.create(request), "허브 라우트 등록에 성공했습니다.");
+    }
+
+    @GetMapping("/{routeId}")
+    public CommonResponse<RouteResponse> getRoute(@PathVariable UUID routeId) {
+        return CommonResponse.success(routeService.getRoute(routeId), "허브 라우트 조회에 성공했습니다.");
+    }
+
+    @GetMapping
+    public CommonResponse<List<RouteResponse>> getRoutes(Pageable pageable) {
+        Page<RouteResponse> page = routeService.getRoutes(pageable);
+        return CommonResponse.success(page.getContent(), "허브 라우트 목록 조회에 성공했습니다.", PageInfo.from(page));
+    }
+
+    @PatchMapping("/{routeId}")
+    public CommonResponse<RouteResponse> updateRoute(
+            @PathVariable UUID routeId,
+            @RequestHeader("X-User-Role") String userRole,
+            @Valid @RequestBody RouteUpdateRequest request) {
+        checkMaster(userRole);
+        return CommonResponse.success(routeService.updateRoute(routeId, request), "허브 라우트 수정에 성공했습니다.");
+    }
+
+    @DeleteMapping("/{routeId}")
+    public CommonResponse<RouteDeleteResponse> deleteRoute(
+            @PathVariable UUID routeId,
+            @RequestHeader("X-User-Role") String userRole) {
+        checkMaster(userRole);
+        return CommonResponse.success(routeService.deleteRoute(routeId), "허브 라우트 삭제에 성공했습니다.");
+    }
+
+    @PostMapping("/calculate")
+    public CommonResponse<RouteCalculateResponse> calculate(
+            @Valid @RequestBody RouteCalculateRequest request) {
+        return CommonResponse.success(routeService.calculate(request), "허브 경로 계산에 성공했습니다.");
+    }
+
+    private void checkMaster(String userRole) {
+        if (!"ROLE_MASTER".equals(userRole)) {
+            throw new ForbiddenException("마스터 관리자만 수행할 수 있는 작업입니다.");
+        }
+    }
+}

--- a/src/main/java/com/loopang/route_service/presentation/dto/request/RouteCalculateRequest.java
+++ b/src/main/java/com/loopang/route_service/presentation/dto/request/RouteCalculateRequest.java
@@ -1,0 +1,20 @@
+package com.loopang.route_service.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RouteCalculateRequest {
+
+    @NotNull(message = "출발 허브 ID는 필수입니다.")
+    private UUID fromHubId;
+
+    @NotNull(message = "도착 허브 ID는 필수입니다.")
+    private UUID toHubId;
+}

--- a/src/main/java/com/loopang/route_service/presentation/dto/request/RouteCreateRequest.java
+++ b/src/main/java/com/loopang/route_service/presentation/dto/request/RouteCreateRequest.java
@@ -1,0 +1,28 @@
+package com.loopang.route_service.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RouteCreateRequest {
+
+    @NotNull(message = "출발 허브 ID는 필수입니다.")
+    private UUID fromHubId;
+
+    @NotNull(message = "도착 허브 ID는 필수입니다.")
+    private UUID toHubId;
+
+    @NotNull(message = "거리는 필수입니다.")
+    private Double distance;
+
+    @NotNull(message = "소요 시간은 필수입니다.")
+    private Double duration;
+
+    private Boolean isActive;
+}

--- a/src/main/java/com/loopang/route_service/presentation/dto/request/RouteCreateRequest.java
+++ b/src/main/java/com/loopang/route_service/presentation/dto/request/RouteCreateRequest.java
@@ -1,6 +1,7 @@
 package com.loopang.route_service.presentation.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,9 +20,11 @@ public class RouteCreateRequest {
     private UUID toHubId;
 
     @NotNull(message = "거리는 필수입니다.")
+    @PositiveOrZero(message = "거리는 0 이상이어야 합니다.")
     private Double distance;
 
     @NotNull(message = "소요 시간은 필수입니다.")
+    @PositiveOrZero(message = "소요 시간은 0 이상이어야 합니다.")
     private Double duration;
 
     private Boolean isActive;

--- a/src/main/java/com/loopang/route_service/presentation/dto/request/RouteUpdateRequest.java
+++ b/src/main/java/com/loopang/route_service/presentation/dto/request/RouteUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.loopang.route_service.presentation.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RouteUpdateRequest {
+
+    private Double distance;
+    private Double duration;
+    private Boolean isActive;
+}

--- a/src/main/java/com/loopang/route_service/presentation/dto/request/RouteUpdateRequest.java
+++ b/src/main/java/com/loopang/route_service/presentation/dto/request/RouteUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.loopang.route_service.presentation.dto.request;
 
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class RouteUpdateRequest {
 
+    @PositiveOrZero(message = "거리는 0 이상이어야 합니다.")
     private Double distance;
+
+    @PositiveOrZero(message = "소요 시간은 0 이상이어야 합니다.")
     private Double duration;
+
     private Boolean isActive;
 }

--- a/src/main/java/com/loopang/route_service/presentation/dto/response/RouteCalculateResponse.java
+++ b/src/main/java/com/loopang/route_service/presentation/dto/response/RouteCalculateResponse.java
@@ -1,0 +1,36 @@
+package com.loopang.route_service.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class RouteCalculateResponse {
+
+    private UUID fromHubId;
+    private UUID toHubId;
+    private List<PathNode> path;
+    private List<RouteEdge> routeEdges;
+    private Double totalDistance;
+    private Double totalDuration;
+
+    @Getter
+    @Builder
+    public static class PathNode {
+        private int sequence;
+        private UUID hubId;
+    }
+
+    @Getter
+    @Builder
+    public static class RouteEdge {
+        private int sequence;
+        private UUID fromHubId;
+        private UUID toHubId;
+        private Double distance;
+        private Double duration;
+    }
+}

--- a/src/main/java/com/loopang/route_service/presentation/dto/response/RouteCalculateResponse.java
+++ b/src/main/java/com/loopang/route_service/presentation/dto/response/RouteCalculateResponse.java
@@ -1,5 +1,6 @@
 package com.loopang.route_service.presentation.dto.response;
 
+import com.loopang.route_service.domain.service.dto.RouteCalculationResult;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,6 +17,27 @@ public class RouteCalculateResponse {
     private List<RouteEdge> routeEdges;
     private Double totalDistance;
     private Double totalDuration;
+
+    public static RouteCalculateResponse from(RouteCalculationResult result) {
+        return RouteCalculateResponse.builder()
+                .fromHubId(result.fromHubId())
+                .toHubId(result.toHubId())
+                .path(result.path().stream()
+                        .map(n -> PathNode.builder().sequence(n.sequence()).hubId(n.hubId()).build())
+                        .toList())
+                .routeEdges(result.routeEdges().stream()
+                        .map(e -> RouteEdge.builder()
+                                .sequence(e.sequence())
+                                .fromHubId(e.fromHubId())
+                                .toHubId(e.toHubId())
+                                .distance(e.distance())
+                                .duration(e.duration())
+                                .build())
+                        .toList())
+                .totalDistance(result.totalDistance())
+                .totalDuration(result.totalDuration())
+                .build();
+    }
 
     @Getter
     @Builder

--- a/src/main/java/com/loopang/route_service/presentation/dto/response/RouteDeleteResponse.java
+++ b/src/main/java/com/loopang/route_service/presentation/dto/response/RouteDeleteResponse.java
@@ -1,0 +1,15 @@
+package com.loopang.route_service.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class RouteDeleteResponse {
+
+    private UUID routeId;
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/loopang/route_service/presentation/dto/response/RouteResponse.java
+++ b/src/main/java/com/loopang/route_service/presentation/dto/response/RouteResponse.java
@@ -1,0 +1,33 @@
+package com.loopang.route_service.presentation.dto.response;
+
+import com.loopang.route_service.domain.entity.HubRoute;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class RouteResponse {
+
+    private UUID routeId;
+    private UUID fromHubId;
+    private UUID toHubId;
+    private Double distance;
+    private Double duration;
+    private boolean isActive;
+    private LocalDateTime createdAt;
+
+    public static RouteResponse from(HubRoute route) {
+        return RouteResponse.builder()
+                .routeId(route.getId())
+                .fromHubId(route.getFromHubId())
+                .toHubId(route.getToHubId())
+                .distance(route.getDistance())
+                .duration(route.getDuration())
+                .isActive(route.isActive())
+                .createdAt(route.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/loopang/route_service/presentation/dto/response/RouteResponse.java
+++ b/src/main/java/com/loopang/route_service/presentation/dto/response/RouteResponse.java
@@ -1,5 +1,6 @@
 package com.loopang.route_service.presentation.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.loopang.route_service.domain.entity.HubRoute;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +17,12 @@ public class RouteResponse {
     private UUID toHubId;
     private Double distance;
     private Double duration;
+
+    // Lombok이 boolean isActive 필드에 생성하는 getter는 isActive()라 Jackson이 기본값으로 "active"로 직렬화한다.
+    // 요청 DTO의 isActive 필드와 대칭 맞추기 위해 JSON 이름을 명시적으로 고정한다.
+    @JsonProperty("isActive")
     private boolean isActive;
+
     private LocalDateTime createdAt;
 
     public static RouteResponse from(HubRoute route) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,7 +14,7 @@ spring:
 
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${DB_URL:localhost:5435/hub}
+    url: jdbc:postgresql://${DB_URL:localhost:5435/route}
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD:postgres}
   jpa:
@@ -37,6 +37,9 @@ eureka:
 
 server:
   port: 18105
+
+tmap:
+  api-key: ${TMAP_API_KEY}
 
 management:
   endpoints:


### PR DESCRIPTION
## 📌 작업 유형
- [x] 신규 기능 추가

## ✅ 작업 내용
- HubRoute 엔티티 + CRUD + MASTER 권한 체크
- 다익스트라 경로 계산 (POST /api/hub-routes/calculate)
  - path(경유 허브) + routeEdges(구간별 거리/시간) + total
- 혼잡도 가중 경로 (Hub Service Feign으로 상태 조회)
  - NORMAL: 가중 없음 / BUSY: 80% 가중 / FULL: 200% 가중
- TMap API 연동 (1시간 스케줄러, 실제 도로 거리/시간)
- Hub Service Feign으로 허브 목록/좌표 조회 (하드코딩 제거)
- 초기 데이터: Haversine → TMap 자동 갱신
- 150km 초과 라우트 자동 비활성화
- 예외 분리 (RouteNotFoundException, RouteCalculationException, DuplicateRouteException)
- README 상세 작성

Closes #1

## 🧪 테스트 / 확인 방법
- [x] 로컬 빌드 확인 (BUILD SUCCESSFUL)
- [x] 서울→부산 경로 계산 테스트 완료 (TMap 실제 도로 거리 480.7km)
- [x] TMap 스케줄러 동작 확인

## ⚠️ 영향 범위
- [x] API 스펙 변경
- [x] DB 스키마 변경
- [x] 비즈니스 로직 변경
- [x] 문서(README) 수정

## 👀 리뷰 포인트
- 다익스트라 혼잡도 가중 비용 계산 방식
- TMap API 호출 rate limit 대응 (200ms 딜레이)
- Hub Service Feign 실패 시 기본값(NORMAL) 처리
- 초기 데이터 생성 전략 (Hub Service 먼저 시작 필요)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 허브 간 경로 CRUD 및 페이지 조회 API 제공(생성/수정/삭제 시 상태·유효성 검사 포함)
  * 허브 혼잡도 가중치 반영한 최단 경로 계산 API 추가(경로 및 엣지별 세부 응답 포함)
  * 외부 지도(TMap) 연동으로 거리·소요시간을 정기 갱신하는 스케줄러 추가
  * 초기 허브 목록 기반 일괄 경로 생성 및 150km 초과 경로 자동 비활성화 규칙 적용
  * 관리자(마스터 역할) 전용 엔드포인트 보호 적용

* **Documentation**
  * 서비스 개요, API 명세, 예제 요청/응답, 운영환경 및 설정 안내 README 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->