### PR TITLE
feat: 업체↔허브 거리 계산 internal API (Kakao Mobility)

### DIFF
--- a/src/main/java/com/loopang/route_service/application/HubPointService.java
+++ b/src/main/java/com/loopang/route_service/application/HubPointService.java
@@ -1,0 +1,114 @@
+package com.loopang.route_service.application;
+
+import com.loopang.route_service.domain.exception.HubLookupException;
+import com.loopang.route_service.domain.service.HaversineCalculator;
+import com.loopang.route_service.domain.service.RouteDistanceProvider;
+import com.loopang.route_service.domain.service.RouteDistanceProvider.DistanceResult;
+import com.loopang.route_service.domain.service.dto.HubData;
+import com.loopang.route_service.domain.vo.Direction;
+import com.loopang.route_service.infrastructure.client.HubFeignClient;
+import com.loopang.route_service.presentation.dto.request.HubPointRequest;
+import com.loopang.route_service.presentation.dto.response.HubPointResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+/**
+ * 업체 ↔ 허브 거리/시간 계산.
+ *
+ * <ol>
+ *   <li>hub-service Feign으로 허브 좌표 조회</li>
+ *   <li>{@link Direction}에 따라 출발/도착 결정</li>
+ *   <li>{@link RouteDistanceProvider}(Kakao Mobility)로 거리/시간 계산</li>
+ *   <li>Kakao 호출 실패/null 시 Haversine 보정으로 폴백</li>
+ * </ol>
+ *
+ * <p>본 서비스는 트랜잭션 없음 — 외부 호출만 수행한다.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HubPointService {
+
+    private final HubFeignClient hubFeignClient;
+    private final RouteDistanceProvider routeDistanceProvider;
+
+    public HubPointResponse calculate(HubPointRequest request) {
+        // 1. 허브 좌표 조회
+        HubData hub = fetchHub(request.getHubId());
+        double hubLat = hub.latitude();
+        double hubLon = hub.longitude();
+
+        double pointLat = request.getPoint().getLatitude();
+        double pointLon = request.getPoint().getLongitude();
+
+        // 2. direction에 따라 출발/도착 결정
+        double fromLat, fromLon, toLat, toLon;
+        if (request.getDirection() == Direction.TO_HUB) {
+            // 업체 → 허브
+            fromLat = pointLat;
+            fromLon = pointLon;
+            toLat = hubLat;
+            toLon = hubLon;
+        } else {
+            // 허브 → 업체
+            fromLat = hubLat;
+            fromLon = hubLon;
+            toLat = pointLat;
+            toLon = pointLon;
+        }
+
+        // 3. Kakao 호출
+        DistanceResult result = routeDistanceProvider.getDistance(fromLat, fromLon, toLat, toLon);
+
+        if (result != null) {
+            return HubPointResponse.of(
+                    request.getHubId(),
+                    request.getDirection(),
+                    result.distanceKm(),
+                    result.durationMin(),
+                    "KAKAO"
+            );
+        }
+
+        // 4. 폴백 — Haversine 보정
+        log.warn("[HubPoint] Kakao 호출 실패 → Haversine 폴백 hubId={}", request.getHubId());
+        double fallbackDistance = HaversineCalculator.estimatedRoadDistanceKm(fromLat, fromLon, toLat, toLon);
+        double fallbackDuration = HaversineCalculator.estimatedDurationMin(fallbackDistance);
+
+        return HubPointResponse.of(
+                request.getHubId(),
+                request.getDirection(),
+                Math.round(fallbackDistance * 10) / 10.0,
+                Math.round(fallbackDuration * 10) / 10.0,
+                "HAVERSINE_FALLBACK"
+        );
+    }
+
+    private HubData fetchHub(UUID hubId) {
+        try {
+            HubFeignClient.HubDetailResponse response = hubFeignClient.getHubDetail(hubId);
+            HubData data = response != null ? response.data() : null;
+
+            if (data == null
+                    || data.hubId() == null
+                    || data.latitude() == null
+                    || data.longitude() == null) {
+                throw new HubLookupException(hubId);
+            }
+            // 응답의 hubId가 요청 hubId와 일치하는지 (업스트림 오동작 방어)
+            if (!hubId.equals(data.hubId())) {
+                log.error("[HubPoint] 응답 hubId 불일치: requested={}, returned={}", hubId, data.hubId());
+                throw new HubLookupException(hubId);
+            }
+            return data;
+        } catch (HubLookupException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[HubPoint] hub-service 호출 실패 hubId={}: {}", hubId, e.getMessage());
+            throw new HubLookupException(hubId);
+        }
+    }
+}

--- a/src/main/java/com/loopang/route_service/domain/exception/HubLookupException.java
+++ b/src/main/java/com/loopang/route_service/domain/exception/HubLookupException.java
@@ -1,0 +1,15 @@
+package com.loopang.route_service.domain.exception;
+
+import com.loopang.common.exception.NotFoundException;
+
+import java.util.UUID;
+
+/**
+ * hub-service Feign 호출 결과 허브를 찾지 못했거나 좌표가 비어 있을 때.
+ */
+public class HubLookupException extends NotFoundException {
+
+    public HubLookupException(UUID hubId) {
+        super("허브 정보를 조회할 수 없습니다. hubId=" + hubId);
+    }
+}

--- a/src/main/java/com/loopang/route_service/domain/service/HaversineCalculator.java
+++ b/src/main/java/com/loopang/route_service/domain/service/HaversineCalculator.java
@@ -1,0 +1,44 @@
+package com.loopang.route_service.domain.service;
+
+/**
+ * Haversine 공식 기반 두 좌표 간 거리/시간 계산기.
+ *
+ * <p>외부 라우팅 API(Kakao, TMap)가 실패하거나 사용 불가일 때 폴백으로 사용한다.
+ * 직선거리에 보정 계수({@value #ROAD_FACTOR})를 곱해 도로거리를 근사한다.
+ * 한국 평균 시외 화물 기준 60km/h를 가정해 시간을 계산한다.</p>
+ */
+public final class HaversineCalculator {
+
+    private static final double EARTH_RADIUS_KM = 6371.0088;
+
+    /** 직선거리 → 도로거리 근사 보정 계수 (한국 평균 약 1.3) */
+    public static final double ROAD_FACTOR = 1.3;
+
+    /** 평균 주행 속도 (km/h) — 시외 화물 기준 */
+    public static final double AVG_SPEED_KMH = 60.0;
+
+    private HaversineCalculator() {}
+
+    /** 두 좌표 간 직선거리 (km). */
+    public static double straightLineKm(double lat1, double lon1, double lat2, double lon2) {
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                 + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                 * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return EARTH_RADIUS_KM * c;
+    }
+
+    /** 도로 거리 근사 (km) = 직선거리 × ROAD_FACTOR. */
+    public static double estimatedRoadDistanceKm(double lat1, double lon1, double lat2, double lon2) {
+        return straightLineKm(lat1, lon1, lat2, lon2) * ROAD_FACTOR;
+    }
+
+    /** 예상 소요 시간 (분) = (거리 / 평균속도) × 60. */
+    public static double estimatedDurationMin(double distanceKm) {
+        return (distanceKm / AVG_SPEED_KMH) * 60;
+    }
+}

--- a/src/main/java/com/loopang/route_service/domain/service/RouteDistanceProvider.java
+++ b/src/main/java/com/loopang/route_service/domain/service/RouteDistanceProvider.java
@@ -1,0 +1,23 @@
+package com.loopang.route_service.domain.service;
+
+/**
+ * 두 지점 간 실제 도로 거리/시간을 계산하는 외부 라우팅 제공자.
+ *
+ * <p>구현체는 외부 API(Kakao Mobility, TMap, OSRM 등)나 로컬 알고리즘(Haversine 보정)을 사용한다.
+ * 도메인 코드는 본 인터페이스만 의존하므로 제공자 교체가 자유롭다.</p>
+ */
+public interface RouteDistanceProvider {
+
+    /**
+     * 출발 → 도착 좌표 사이의 자동차 도로 거리/시간을 반환한다.
+     *
+     * @param fromLat 출발 위도
+     * @param fromLon 출발 경도
+     * @param toLat   도착 위도
+     * @param toLon   도착 경도
+     * @return 거리(km) + 시간(분). 호출 실패 시 {@code null} 또는 구현체별 폴백 값.
+     */
+    DistanceResult getDistance(double fromLat, double fromLon, double toLat, double toLon);
+
+    record DistanceResult(double distanceKm, double durationMin) {}
+}

--- a/src/main/java/com/loopang/route_service/domain/vo/Direction.java
+++ b/src/main/java/com/loopang/route_service/domain/vo/Direction.java
@@ -1,0 +1,13 @@
+package com.loopang.route_service.domain.vo;
+
+/**
+ * 업체 ↔ 허브 구간의 방향.
+ *
+ * <p>실제 도로는 일방통행/우회 등으로 방향에 따라 거리가 다를 수 있어 명시적으로 받는다.</p>
+ */
+public enum Direction {
+    /** 업체 → 허브 (첫 마일 / pickup) */
+    TO_HUB,
+    /** 허브 → 업체 (마지막 마일 / delivery) */
+    FROM_HUB
+}

--- a/src/main/java/com/loopang/route_service/infrastructure/client/HubFeignClient.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/client/HubFeignClient.java
@@ -15,8 +15,18 @@ public interface HubFeignClient {
     @GetMapping("/api/hubs/{hubId}")
     HubStatusData getHub(@PathVariable("hubId") UUID hubId);
 
+    /**
+     * 허브 단건 상세 조회 — 좌표(latitude/longitude) 포함.
+     * <p>응답 본문이 {@code {"data": {...}, "message": "..."}} 형식이라
+     * 내부 record로 한 번 unwrap한다.</p>
+     */
+    @GetMapping("/api/hubs/{hubId}")
+    HubDetailResponse getHubDetail(@PathVariable("hubId") UUID hubId);
+
     @GetMapping("/api/hubs?size=50")
     HubListResponse getHubs();
 
     record HubListResponse(List<HubData> data) {}
+
+    record HubDetailResponse(HubData data) {}
 }

--- a/src/main/java/com/loopang/route_service/infrastructure/kakao/KakaoDirectionsResponse.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/kakao/KakaoDirectionsResponse.java
@@ -1,0 +1,44 @@
+package com.loopang.route_service.infrastructure.kakao;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * Kakao Mobility Directions API 응답.
+ * <p>전체 응답 중 본 서비스가 사용하는 필드만 매핑한다 (route 단위 distance/duration).</p>
+ *
+ * <pre>
+ * {
+ *   "trans_id": "...",
+ *   "routes": [
+ *     {
+ *       "result_code": 0,
+ *       "result_msg": "길찾기 성공",
+ *       "summary": {
+ *         "distance": 384008,   // meters
+ *         "duration": 16623     // seconds
+ *       }
+ *     }
+ *   ]
+ * }
+ * </pre>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoDirectionsResponse(
+        List<Route> routes
+) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Route(
+            int result_code,
+            String result_msg,
+            Summary summary
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Summary(
+            int distance,    // meters
+            int duration     // seconds
+    ) {}
+}

--- a/src/main/java/com/loopang/route_service/infrastructure/kakao/KakaoDirectionsResponse.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/kakao/KakaoDirectionsResponse.java
@@ -31,14 +31,20 @@ public record KakaoDirectionsResponse(
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record Route(
-            int result_code,
+            Integer result_code,
             String result_msg,
             Summary summary
     ) {}
 
+    /**
+     * primitive 대신 {@code Integer}를 쓰는 이유:
+     * Jackson은 primitive 필드가 JSON에 누락되면 자동으로 0으로 채운다.
+     * 그러면 깨진 응답을 {@code distance=0, duration=0}인 정상 응답으로 오인할 수 있다.
+     * Integer로 두면 누락 시 {@code null}이 되어 호출 측에서 명시적으로 검증할 수 있다.
+     */
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record Summary(
-            int distance,    // meters
-            int duration     // seconds
+            Integer distance,    // meters
+            Integer duration     // seconds
     ) {}
 }

--- a/src/main/java/com/loopang/route_service/infrastructure/kakao/KakaoMobilityProviderImpl.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/kakao/KakaoMobilityProviderImpl.java
@@ -1,0 +1,93 @@
+package com.loopang.route_service.infrastructure.kakao;
+
+import com.loopang.route_service.domain.service.RouteDistanceProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+/**
+ * Kakao Mobility Directions API 기반 거리/시간 제공자.
+ *
+ * <p>요청:
+ * <pre>
+ * GET https://apis-navi.kakaomobility.com/v1/directions?origin=lng,lat&destination=lng,lat
+ * Authorization: KakaoAK {REST_API_KEY}
+ * </pre></p>
+ *
+ * <p>응답의 {@code summary.distance}(미터)와 {@code summary.duration}(초)을 km/분으로 변환해 반환.
+ * 호출 실패 / 응답 이상 시 {@code null}을 반환하며, 호출자({@code HubPointService})가 폴백을 결정한다.</p>
+ *
+ * <p><b>주의:</b> Kakao API의 좌표 순서는 ({@code longitude}, {@code latitude})임에 유의.</p>
+ */
+@Slf4j
+@Component
+public class KakaoMobilityProviderImpl implements RouteDistanceProvider {
+
+    private static final String DIRECTIONS_URL = "https://apis-navi.kakaomobility.com/v1/directions";
+
+    private final RestTemplate restTemplate;
+    private final KakaoProperties properties;
+
+    public KakaoMobilityProviderImpl(@Qualifier("kakaoRestTemplate") RestTemplate restTemplate,
+                                     KakaoProperties properties) {
+        this.restTemplate = restTemplate;
+        this.properties = properties;
+    }
+
+    @Override
+    public DistanceResult getDistance(double fromLat, double fromLon, double toLat, double toLon) {
+        URI uri = UriComponentsBuilder.fromUriString(DIRECTIONS_URL)
+                .queryParam("origin", fromLon + "," + fromLat)       // ← x,y (lng,lat)
+                .queryParam("destination", toLon + "," + toLat)
+                .build(true)
+                .toUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + properties.getRestApiKey());
+
+        try {
+            ResponseEntity<KakaoDirectionsResponse> response = restTemplate.exchange(
+                    uri, HttpMethod.GET, new HttpEntity<>(headers), KakaoDirectionsResponse.class);
+
+            KakaoDirectionsResponse body = response.getBody();
+            if (body == null || body.routes() == null || body.routes().isEmpty()) {
+                log.warn("[Kakao] 응답 비어있음: ({},{}) → ({},{})", fromLat, fromLon, toLat, toLon);
+                return null;
+            }
+
+            KakaoDirectionsResponse.Route route = body.routes().get(0);
+            if (route.result_code() != 0 || route.summary() == null) {
+                log.warn("[Kakao] 길찾기 실패 result_code={} msg={}", route.result_code(), route.result_msg());
+                return null;
+            }
+
+            double distanceKm = route.summary().distance() / 1000.0;
+            double durationMin = route.summary().duration() / 60.0;
+
+            log.debug("[Kakao] ({},{}) → ({},{}) = {}km, {}min",
+                    fromLat, fromLon, toLat, toLon, distanceKm, durationMin);
+
+            return new DistanceResult(
+                    Math.round(distanceKm * 10) / 10.0,
+                    Math.round(durationMin * 10) / 10.0
+            );
+        } catch (RestClientException e) {
+            log.error("[Kakao] API 호출 실패: ({},{}) → ({},{}): {}",
+                    fromLat, fromLon, toLat, toLon, e.getMessage());
+            return null;
+        } catch (Exception e) {
+            log.error("[Kakao] 응답 파싱 실패: ({},{}) → ({},{}): {}",
+                    fromLat, fromLon, toLat, toLon, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/loopang/route_service/infrastructure/kakao/KakaoMobilityProviderImpl.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/kakao/KakaoMobilityProviderImpl.java
@@ -65,13 +65,20 @@ public class KakaoMobilityProviderImpl implements RouteDistanceProvider {
             }
 
             KakaoDirectionsResponse.Route route = body.routes().get(0);
-            if (route.result_code() != 0 || route.summary() == null) {
+            if (route.result_code() == null || route.result_code() != 0 || route.summary() == null) {
                 log.warn("[Kakao] 길찾기 실패 result_code={} msg={}", route.result_code(), route.result_msg());
                 return null;
             }
 
-            double distanceKm = route.summary().distance() / 1000.0;
-            double durationMin = route.summary().duration() / 60.0;
+            Integer distanceM = route.summary().distance();
+            Integer durationSec = route.summary().duration();
+            if (distanceM == null || durationSec == null || distanceM < 0 || durationSec < 0) {
+                log.warn("[Kakao] 응답 distance/duration 이상: distance={}, duration={}", distanceM, durationSec);
+                return null;
+            }
+
+            double distanceKm = distanceM / 1000.0;
+            double durationMin = durationSec / 60.0;
 
             log.debug("[Kakao] ({},{}) → ({},{}) = {}km, {}min",
                     fromLat, fromLon, toLat, toLon, distanceKm, durationMin);

--- a/src/main/java/com/loopang/route_service/infrastructure/kakao/KakaoProperties.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/kakao/KakaoProperties.java
@@ -1,0 +1,24 @@
+package com.loopang.route_service.infrastructure.kakao;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Kakao Mobility Directions API 호출 설정.
+ * <p>application.yaml의 {@code kakao.rest-api-key} 값을 받아 보관한다.
+ * 환경변수 {@code KAKAO_REST_API_KEY}로 주입하는 것을 권장한다.</p>
+ */
+@Getter
+@Setter
+@Component
+@Validated
+@ConfigurationProperties(prefix = "kakao")
+public class KakaoProperties {
+
+    @NotBlank(message = "kakao.rest-api-key는 필수입니다.")
+    private String restApiKey;
+}

--- a/src/main/java/com/loopang/route_service/infrastructure/kakao/KakaoRestTemplateConfig.java
+++ b/src/main/java/com/loopang/route_service/infrastructure/kakao/KakaoRestTemplateConfig.java
@@ -1,0 +1,24 @@
+package com.loopang.route_service.infrastructure.kakao;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class KakaoRestTemplateConfig {
+
+    /**
+     * Kakao Mobility Directions API 전용 RestTemplate.
+     * 호출 스레드가 무한정 블로킹되지 않도록 timeout을 명시.
+     */
+    @Bean
+    public RestTemplate kakaoRestTemplate(RestTemplateBuilder builder) {
+        return builder
+                .connectTimeout(Duration.ofSeconds(3))
+                .readTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+}

--- a/src/main/java/com/loopang/route_service/presentation/InternalHubPointController.java
+++ b/src/main/java/com/loopang/route_service/presentation/InternalHubPointController.java
@@ -1,0 +1,43 @@
+package com.loopang.route_service.presentation;
+
+import com.loopang.common.response.CommonResponse;
+import com.loopang.route_service.application.HubPointService;
+import com.loopang.route_service.presentation.dto.request.HubPointRequest;
+import com.loopang.route_service.presentation.dto.response.HubPointResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 내부 서비스 호출 전용 — 업체 ↔ 허브 거리/시간 계산.
+ *
+ * <p>delivery-service 등 다른 MSA 컴포넌트가 Feign으로 호출한다.
+ * 권한 검증이 없으며, 운영 환경에서는 ALB Listener Rule 또는 Security Group으로
+ * {@code /internal/**}을 외부에서 직접 호출하는 트래픽을 차단해야 한다.</p>
+ *
+ * <p>외부 클라이언트가 gateway를 통해 접근할 수 없도록, gateway 라우팅에는
+ * {@code /internal/hub-routes/**} 경로를 등록하지 않는다.</p>
+ */
+@RestController
+@RequestMapping("/internal/hub-routes")
+@RequiredArgsConstructor
+public class InternalHubPointController {
+
+    private final HubPointService hubPointService;
+
+    /**
+     * 업체 좌표(point) ↔ 허브(hubId) 사이의 자동차 도로 거리/시간 계산.
+     * <p>제공자: Kakao Mobility Directions API.
+     * 호출 실패 시 Haversine 보정으로 자동 폴백.</p>
+     */
+    @PostMapping("/hub-point")
+    public CommonResponse<HubPointResponse> calculate(@Valid @RequestBody HubPointRequest request) {
+        return CommonResponse.success(
+                hubPointService.calculate(request),
+                "허브-지점 거리 계산에 성공했습니다."
+        );
+    }
+}

--- a/src/main/java/com/loopang/route_service/presentation/dto/request/HubPointRequest.java
+++ b/src/main/java/com/loopang/route_service/presentation/dto/request/HubPointRequest.java
@@ -1,0 +1,47 @@
+package com.loopang.route_service.presentation.dto.request;
+
+import com.loopang.route_service.domain.vo.Direction;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+/**
+ * 업체 ↔ 허브 거리/시간 계산 요청.
+ *
+ * <ul>
+ *   <li>{@code hubId}: route-service가 hub-service Feign으로 좌표 조회</li>
+ *   <li>{@code point}: 호출자(delivery-service)가 보유한 업체 좌표 (lat/lon)</li>
+ *   <li>{@code direction}: TO_HUB(업체→허브) / FROM_HUB(허브→업체)</li>
+ * </ul>
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class HubPointRequest {
+
+    @NotNull(message = "hubId는 필수입니다.")
+    private UUID hubId;
+
+    @NotNull(message = "point는 필수입니다.")
+    @Valid
+    private GeoPoint point;
+
+    @NotNull(message = "direction은 필수입니다. (TO_HUB 또는 FROM_HUB)")
+    private Direction direction;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GeoPoint {
+
+        @NotNull(message = "latitude는 필수입니다.")
+        private Double latitude;
+
+        @NotNull(message = "longitude는 필수입니다.")
+        private Double longitude;
+    }
+}

--- a/src/main/java/com/loopang/route_service/presentation/dto/response/HubPointResponse.java
+++ b/src/main/java/com/loopang/route_service/presentation/dto/response/HubPointResponse.java
@@ -1,0 +1,32 @@
+package com.loopang.route_service.presentation.dto.response;
+
+import com.loopang.route_service.domain.vo.Direction;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+/**
+ * 업체 ↔ 허브 거리/시간 계산 응답.
+ */
+@Getter
+@Builder
+public class HubPointResponse {
+
+    private UUID hubId;
+    private Direction direction;
+    private Double distance;     // km
+    private Double duration;     // minutes
+    private String provider;     // "KAKAO" 또는 "HAVERSINE_FALLBACK"
+
+    public static HubPointResponse of(UUID hubId, Direction direction,
+                                       double distance, double duration, String provider) {
+        return HubPointResponse.builder()
+                .hubId(hubId)
+                .direction(direction)
+                .distance(distance)
+                .duration(duration)
+                .provider(provider)
+                .build();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,6 +41,9 @@ server:
 tmap:
   api-key: ${TMAP_API_KEY}
 
+kakao:
+  rest-api-key: ${KAKAO_REST_API_KEY}
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## 📌 작업 유형
- [x] 신규 기능 추가

## ✅ 작업 내용

### 신규 엔드포인트
\`POST /internal/hub-routes/hub-point\` — 업체 ↔ 허브 자동차 도로 거리/시간 계산

**Request:**
\`\`\`json
{
  "hubId": "uuid",
  "point": { "latitude": 37.5, "longitude": 127.0 },
  "direction": "TO_HUB"
}
\`\`\`
- \`direction\`: \`TO_HUB\` (업체→허브 첫 마일) / \`FROM_HUB\` (허브→업체 마지막 마일)

**Response:**
\`\`\`json
{
  "data": {
    "hubId": "uuid",
    "direction": "TO_HUB",
    "distance": 12.3,
    "duration": 25.0,
    "provider": "KAKAO"
  },
  "message": "허브-지점 거리 계산에 성공했습니다."
}
\`\`\`

### 흐름
1. \`HubFeignClient.getHubDetail(hubId)\` — hub-service에서 좌표 조회
2. \`direction\`에 따라 origin/destination 결정 (Kakao API 좌표 순서: \`lng,lat\`)
3. \`KakaoMobilityProviderImpl.getDistance(...)\` — Kakao Mobility Directions API 호출
4. 호출 실패/응답 이상 시 \`HaversineCalculator\`로 폴백 (직선거리 × 1.3, 60km/h)

### 책임 분리
- 호출자(delivery-service)는 **업체 좌표(lat/lon)만 전달** — \`companyId\` 안 받음
- route-service가 company-service에 결합되지 않음 (도메인 경계 유지)
- hub 좌표는 route-service가 hub-service Feign으로 조회

### Provider 패턴
- \`domain/service/RouteDistanceProvider\` 인터페이스 (도메인 추상화)
- \`infrastructure/kakao/KakaoMobilityProviderImpl\` (Kakao 구현)
- 추후 OSRM, TMap 등으로 교체 가능

### Gateway 라우팅
**추가하지 않음** (보안 강화). 내부 Feign 호출은 Eureka 디스커버리로 route-service에 직접 도달.
user-service의 \`/internal/users/**\`, \`/internal/couriers/**\`와 동일 정책.

### 환경 변수
\`\`\`bash
export KAKAO_REST_API_KEY=...
\`\`\`
\`application.yaml\`에 \`kakao.rest-api-key: \${KAKAO_REST_API_KEY}\` 추가.

## 🧪 테스트 / 확인 방법
- [x] 로컬 빌드 성공 (BUILD SUCCESSFUL)
- [x] **실제 Kakao API 호출 확인** — 서울→부산 384km / 4h 37min 응답 정상
- [ ] delivery-service 측 통합 테스트 (배송 담당자 작업 후)

## ⚠️ 영향 범위
- [x] API 신규 추가
- [x] 외부 서비스 의존성 추가 (Kakao Mobility)
- [x] hub-service Feign 호출 추가 (\`getHubDetail\` — 좌표 포함 응답)

## 👀 리뷰 포인트
- Kakao API 좌표 순서는 \`lng,lat\` (x,y) — 코드의 조립 부분 검토
- 폴백 정책 (Kakao 실패 시 Haversine 보정 — \`provider\` 필드로 응답에 표시)
- \`HubFeignClient.getHubDetail\` 신규 메서드 (기존 \`getHub\` 그대로 두고 추가)
- \`/internal/hub-routes/**\`은 gateway 라우팅에 추가하지 않음 (보안)
- \`HaversineCalculator\` 정적 유틸 — 기존 \`HubRouteInitializer\`의 인라인 메서드를 추출 (TODO: HubRouteInitializer도 이 유틸 사용하도록 follow-up)

## 🤝 연관 작업
- delivery-service: \`RouteFeignClient\`에 \`/internal/hub-routes/hub-point\` 호출 추가, segment 조립 (현빈님 작업)
- 이번 PR의 SLA: 배송 도메인 unblock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 허브↔지점 간 거리·소요시간 계산 API 추가
  * 카카오 모빌리티 기반 실도로 거리/시간 조회 제공
  * 카카오 응답 실패 시 해버사인 추정치로 자동 대체 제공

* **개선사항**
  * 허브 조회 및 입력값 검증 강화(누락/불일치 시 명확한 오류 처리)
  * 카카오 호출 전용 타임아웃 설정으로 외부 연동 안정성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->