### PR TITLE
chore: spring-dotenv 도입 (로컬 환경 변수 자동 로드)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# route-service 로컬 환경 변수 템플릿
+# 사용법: 본 파일을 .env로 복사한 뒤 실제 값으로 채워넣는다 (cp .env.example .env)
+# .env 파일은 .gitignore에 등록되어 커밋되지 않는다.
+
+# ─── DB ─────────────────────────────────────────
+DB_URL=localhost:5435/route
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+
+# ─── Eureka ──────────────────────────────────────
+EUREKA_SERVER_URL=http://localhost:18761/eureka
+
+# ─── 외부 라우팅 API ─────────────────────────────
+# 허브↔허브 — TMap (스케줄러용)
+TMAP_API_KEY=
+
+# 업체↔허브 — Kakao Mobility Directions API
+KAKAO_REST_API_KEY=

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.postgresql:postgresql'
 
+	// .env 파일 자동 로딩 (로컬 개발용 환경 변수 관리)
+	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 


### PR DESCRIPTION
## 📌 작업 유형
- [x] 환경 설정 / 의존성 추가

## ✅ 작업 내용

### spring-dotenv 도입
- \`build.gradle\`에 \`me.paulschwarz:spring-dotenv:4.0.0\` 추가
- 프로젝트 루트의 \`.env\` 파일을 자동으로 환경변수로 로드
- IntelliJ Run Configuration에 환경변수 일일이 입력할 필요 없음
- \`.env\`는 이미 \`.gitignore\`에 등록 → 커밋 안 됨
- \`.env.example\` 추가 — 템플릿 (실제 API 키 비움, 커밋됨)

### 보안
- \`TMAP_API_KEY\`, \`KAKAO_REST_API_KEY\`, \`DB_*\` 모두 환경변수로만 (코드/yaml에 노출 X)
- \`.env.example\`에는 키 이름만 있고 값은 빈 상태

### 참고
route-service는 Kafka 미사용이라 hub/user-service와 달리 SSL 설정 없음.

## 🧪 사용법

1. 본 PR 머지 후:
   \`\`\`bash
   cp .env.example .env
   # .env 파일을 열어 실제 값 채워넣기 (TMAP/KAKAO 키 등)
   \`\`\`
2. IntelliJ에서 그냥 Run → spring-dotenv가 .env 자동 로드

## ⚠️ 영향 범위
- 의존성 추가만 (코드 변경 없음)

## 🤝 연관 작업
- hub-service, user-service에도 동일한 .env 패턴 적용 (각각 별도 PR)