### PR TITLE
fix: spring-dotenv 명시적 import 추가

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,7 +4,9 @@ spring:
   profiles:
     active: dev
   config:
-    import: 'optional:configserver:'
+    import:
+      - 'optional:dotenv:'
+      - 'optional:configserver:'
 
   cloud:
     config:


### PR DESCRIPTION
## 배경

로컬에서 route-service를 띄울 때 \`.env\`의 환경변수가 placeholder로 풀리지 않아 \`PlaceholderResolutionException\`이 발생하는 현상이 있었습니다.

## 원인

\`me.paulschwarz:spring-dotenv\` 4.0.0부터는 자동 PropertySource 등록이 빠져서, \`spring.config.import\`에 \`optional:dotenv:\`를 명시적으로 넣어야 \`.env\` 파일이 로드됩니다. 이전 버전에서는 의존성만 추가하면 자동으로 동작했지만 4.0에서 breaking change가 있었던 부분입니다.

## 변경 내용

\`application.yaml\`의 \`spring.config.import\`를 단일 문자열에서 리스트 형태로 변경하고 \`optional:dotenv:\`를 추가했습니다.

\`\`\`yaml
spring:
  config:
    import:
      - 'optional:dotenv:'      # ← 추가
      - 'optional:configserver:'
\`\`\`

route-service는 Kafka를 직접 쓰지 않기 때문에 이번 PR에는 truststore 관련 변경은 포함되어 있지 않습니다 (hub-service / user-service의 동일 fix에는 포함됨).

## 주의사항

이 PR은 application.yaml 변경만 포함합니다. 로컬에서 정상 기동하려면 추가로:
- 모듈 root에 \`.env\` 파일 (\`.env.example\` 참고)
- IntelliJ Run Config에서 Working directory를 \`\$MODULE_WORKING_DIR\$\`로 설정 (멀티모듈 IntelliJ 프로젝트에서 spring-dotenv가 모듈 폴더의 .env를 찾도록)

🤖 Generated with [Claude Code](https://claude.com/claude-code)