### PR TITLE
chore: 무효한 'optional:dotenv:' import 제거

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,9 +4,7 @@ spring:
   profiles:
     active: dev
   config:
-    import:
-      - 'optional:dotenv:'
-      - 'optional:configserver:'
+    import: 'optional:configserver:'
 
   cloud:
     config:


### PR DESCRIPTION
## 배경

직전 PR (#5)에서 \`spring.config.import\`에 \`optional:dotenv:\`를 추가했는데, hub-service의 동일 PR을 CodeRabbit 리뷰하면서 이 구문이 현재 의존성(\`spring-dotenv 4.0.0\`)에서 **무효한 dead code**임이 확인되었습니다.

## 검증 결과

1. **\`me.paulschwarz:spring-dotenv:4.0.0\`은 자동 로드됩니다.**
   \`META-INF/spring.factories\`에 \`DotenvApplicationRunListener\`가 등록되어 있어, 의존성만 추가하면 \`SpringApplicationRunListener\`로 \`.env\`를 자동으로 PropertySource에 등록합니다.

2. **\`optional:dotenv:\` resolver는 4.0.0에 존재하지 않습니다.**
   해당 구문은 spring-dotenv **5.x** 이상에서 유효한 syntax이며, 4.0.0에서는 unknown resolver로 처리됩니다. \`optional:\` 프리픽스 덕분에 시작 실패는 면하지만 silently 무시됩니다.

3. 따라서 직전 PR의 import 추가는 **동작 변화 없는 dead code**였습니다.

## 변경 내용

\`spring.config.import\`를 단일 string 형태로 복원합니다 (직전 PR 직전 상태).

\`\`\`yaml
spring:
  config:
    import: 'optional:configserver:'
\`\`\`

## 진짜 fix는 무엇이었나?

로컬에서 \`.env\`가 로드되지 않던 진짜 원인은:
- 멀티모듈 IntelliJ 프로젝트(\`/Users/.../loopang/\`)에서 Run Configuration의 Working directory가 프로젝트 루트로 잡혀서 spring-dotenv가 모듈 폴더의 \`.env\`를 못 찾던 것
- IntelliJ Run Config에서 **Working directory를 \`\$MODULE_WORKING_DIR\$\`로 설정**하면 spring-dotenv 4.0.0이 자동으로 모듈 폴더의 \`.env\`를 로드함

이는 yaml 변경이 아니라 IDE 설정이라 PR로 박을 수 없는 부분이라 README에 documentation 추가를 검토할 수 있습니다.

## 영향

- 동작 변화 없음 (dead code 제거)
- route-service는 Kafka를 직접 쓰지 않으므로 truststore 관련 변경은 이 PR에 포함되지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)